### PR TITLE
queryAssertion: allow whole response to be signed

### DIFF
--- a/src/OneLogin/Saml/Response.php
+++ b/src/OneLogin/Saml/Response.php
@@ -114,7 +114,7 @@ class OneLogin_Saml_Response
         }
         $id = substr($assertionReferenceNode->attributes->getNamedItem('URI')->nodeValue, 1);
 
-        $nameQuery = "/samlp:Response//*[@ID='$id']//saml:Assertion" . $assertionXpath;
+        $nameQuery = "//*[@ID='$id']//saml:Assertion" . $assertionXpath;
         return $xpath->query($nameQuery);
     }
 }


### PR DESCRIPTION
Some providers sign the whole response, not just the "Assertion"
element. This change makes the xpaths to find the signature and the
assertion a little more flexible.

Note: The validity of the document is determined elsewhere, this code
mainly tries to find the assertion that _was_ signed.
