### PR TITLE
Redirect URL: support params in redirect url

### DIFF
--- a/src/OneLogin/Saml/AuthRequest.php
+++ b/src/OneLogin/Saml/AuthRequest.php
@@ -58,7 +58,12 @@ AUTHNREQUEST;
         $base64Request = base64_encode($deflatedRequest);
         $encodedRequest = urlencode($base64Request);
 
-        return $this->_settings->idpSingleSignOnUrl . "?SAMLRequest=" . $encodedRequest;
+        if (strstr($this->_settings->idpSingleSignOnUrl, "?") !== false) {
+           $sep = '&';
+        } else {
+           $sep = '?';
+        }
+        return $this->_settings->idpSingleSignOnUrl . "{$sep}SAMLRequest=" . $encodedRequest;
     }
 
     protected function _generateUniqueID()


### PR DESCRIPTION
`$url = "http://blah.com?x=y" . "?Z=" . $value;`
Will obviously not work because the query part of the url now has two ?s

Previously if your url already contained query params, the generated url
would be incorrect.
