### PR TITLE
Added $parameters array to OneLogin_Saml2_Auth->login()

### DIFF
--- a/lib/Saml2/Auth.php
+++ b/lib/Saml2/Auth.php
@@ -244,7 +244,7 @@ class OneLogin_Saml2_Auth
      * @param string $returnTo   The target URL the user should be returned to after login.
      * @param array  $parameters An array of additional parameters to send through to the IdP
      */
-    public function login($returnTo = null, $parameters = [])
+    public function login($returnTo = null, $parameters = array())
     {
         assert('is_array($parameters)');
 


### PR DESCRIPTION
I'm currently using OneLogin_Saml2_Auth to authenticate with an identity provider that requires additional parameters to be sent through along with the SAML request. The login method doesn't currently have the option to pass through additional parameters to the redirection methods, so I've added a $parameters array to the method in order to allow you to pass through additional parameters.

Also, I've added a bit of code to pull them out of the idp section of the settings if it's defined there.
