### PR TITLE
Allow graceful degradation when gettext is not loaded.

### DIFF
--- a/lib/Saml2/Utils.php
+++ b/lib/Saml2/Utils.php
@@ -19,11 +19,14 @@ class OneLogin_Saml2_Utils
     public static function t($msg, $args = array())
     {
         assert('is_string($msg)');
+        if (extension_loaded('gettext')) {
+            bindtextdomain("phptoolkit", dirname(dirname(dirname(__FILE__))).'/locale');
+            textdomain('phptoolkit');
 
-        bindtextdomain("phptoolkit", dirname(dirname(dirname(__FILE__))).'/locale');
-        textdomain('phptoolkit');
-
-        $translatedMsg = gettext($msg);
+            $translatedMsg = gettext($msg);
+        } else {
+            $translatedMsg = $msg;
+        }
         if (!empty($args)) {
             $params = array_merge(array($translatedMsg), $args);
             $translatedMsg = call_user_func_array('sprintf', $params);


### PR DESCRIPTION
OneLogin toolkit may be packaged with other software to be installed on a variety of systems. Sometimes gettext may not be available in those systems. Since it is possible to allow the SAML toolkit still run when gettext is not available, even at the cost of not translating error messages, I think it would be beneficial to provide graceful degradation capability and enable the toolkit to work in environments where gettext is not provided. 
