### PR TITLE
Fix for #43

### DIFF
--- a/lib/Saml2/Response.php
+++ b/lib/Saml2/Response.php
@@ -241,11 +241,11 @@ class OneLogin_Saml2_Response
                     throw new Exception("A valid SubjectConfirmation was not found on this Response");
                 }
 
-                if ($security['wantAssertionsSigned'] && !in_array('saml:Assertion', $signedElements)) {
+                if ($security['wantAssertionsSigned'] && !in_array('Assertion', $signedElements)) {
                     throw new Exception("The Assertion of the Response is not signed and the SP requires it");
                 }
-                
-                if ($security['wantMessagesSigned'] && !in_array('samlp:Response', $signedElements)) {
+
+                if ($security['wantMessagesSigned'] && !in_array('Response', $signedElements)) {
                     throw new Exception("The Message of the Response is not signed and the SP requires it");
                 }
             }
@@ -255,7 +255,7 @@ class OneLogin_Saml2_Response
                 $fingerprint = $idpData['certFingerprint'];
 
                 // Only validates the first signed element
-                if (in_array('samlp:Response', $signedElements)) {
+                if (in_array('Response', $signedElements)) {
                     $documentToValidate = $this->document;
                 } else {
                     $documentToValidate = $signNodes->item(0)->parentNode;


### PR DESCRIPTION
Basically strips the namespace off of the signed elements and does the comparison in a non-namespace fashion.
