### PR TITLE
Adding xml validation as optional

### DIFF
--- a/lib/Saml2/Response.php
+++ b/lib/Saml2/Response.php
@@ -123,11 +123,13 @@ class OneLogin_Saml2_Response
 
             if ($this->_settings->isStrict()) {
 
-                $res = OneLogin_Saml2_Utils::validateXML($this->document, 'saml-schema-protocol-2.0.xsd', $this->_settings->isDebugActive());
-                if (!$res instanceof DOMDocument) {
-                    throw new Exception("Invalid SAML Response. Not match the saml-schema-protocol-2.0.xsd");
+                if ($security['wantValidateXML']) {
+                  $res = OneLogin_Saml2_Utils::validateXML($this->document, 'saml-schema-protocol-2.0.xsd', $this->_settings->isDebugActive());
+                  if (!$res instanceof DOMDocument) {
+                      throw new Exception("Invalid SAML Response. Not match the saml-schema-protocol-2.0.xsd");
+                  }
                 }
-
+                
                 $security = $this->_settings->getSecurityData();
 
                 $currentURL = OneLogin_Saml2_Utils::getSelfRoutedURLNoQuery();

--- a/lib/Saml2/Settings.php
+++ b/lib/Saml2/Settings.php
@@ -329,6 +329,11 @@ class OneLogin_Saml2_Settings
             $this->_security['wantNameIdEncrypted'] = false;
         }
 
+        // xml validation expected
+        if (!isset($this->_security['wantValidateXML'])) {
+          $this->_security['wantValidateXML'] = true;
+        }
+
         if (!isset($this->_idp['x509cert'])) {
             $this->_idp['x509cert'] = '';
         }


### PR DESCRIPTION
I'd like to do all the checks that strict mode does but skip this one. I'm using the same pattern that's used with requiring the assertion and/or the response to be signed.