### PR TITLE
Update documentation: Composer

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,27 +86,18 @@ See the "Guide to add SAML support to my app" to know how.
 
 #### Option 2. Composer ####
 
-The toolkit supports [composer][1]. You can find the onelogin/php-saml package at https://packagist.org/packages/onelogin/php-saml
+The toolkit supports [composer](https://getcomposer.org/). You can find the onelogin/php-saml package at https://packagist.org/packages/onelogin/php-saml
 
-In order to import the saml toolkit to your current php project, just add to the composer.json file this require:
+To install the latest stable release of this package simply type:
 
- "onelogin/php-saml": "master-dev"
+    composer require onelogin/php-saml
 
-Done that, execute:
-```
- composer install
-```
+After this package is installed make sure you are including the autoloader provided by composer. It can be found at `vendor/autoload.php`.
 
-you will find at the "vendor" folder a new folder named *onelogin* and inside the *php-saml*.
-
-Composer will automatically handle the libraries (with require "vendor/autoload.php" you will load all the vendor libraries).
-
-**Important** In this option, the x509 certs must be stored at *vendor/onelogin/php-saml/certs*
-and settings file should be stored at *vendor/onelogin/php-saml*.
-But could be easier to use the "array method" to provide settings info (explained later)
-
-  [1]: https://getcomposer.org/
-
+**Important**
+When installing this package with composer it is **highly** recommended that you pass the options as
+an array to the constructor (explained later in this document). If you do not use this approach your settings are at risk
+of being deleted when updating packages using `composer update` or similiar commands.
 
 Compatibility
 -------------

--- a/README.md
+++ b/README.md
@@ -92,9 +92,14 @@ To install the latest stable release of this package simply type:
 
     composer require onelogin/php-saml
 
-After this package is installed make sure you are including the autoloader provided by composer. It can be found at `vendor/autoload.php`.
+If you instead wish to install the latest (and possibly unstable) version:
+
+    composer require onelogin/php-saml dev-master
+
+After installation has completed make sure you are including the autoloader provided by composer. It can be found at `vendor/autoload.php`.
 
 **Important**
+
 When installing this package with composer it is **highly** recommended that you pass the options as
 an array to the constructor (explained later in this document). If you do not use this approach your settings are at risk
 of being deleted when updating packages using `composer update` or similiar commands.


### PR DESCRIPTION
Simplified instructions on how to install this using composer.

Removed the suggested way of configuring the package as you are not supposed to modify the contents of the `vendor` directory.