### PR TITLE
Allows the RequestedAuthnContext Comparison attribute to be set via config

### DIFF
--- a/advanced_settings_example.php
+++ b/advanced_settings_example.php
@@ -48,9 +48,13 @@ $advancedSettings = array (
 
         // Authentication context.
         // Set to false and no AuthContext will be sent in the AuthNRequest,
-        // Set true or don't present thi parameter and you will get an AuthContext 'exact' 'urn:oasis:names:tc:SAML:2.0:ac:classes:PasswordProtectedTransport'
+        // Set true or don't present this parameter and you will get an AuthContext 'exact' 'urn:oasis:names:tc:SAML:2.0:ac:classes:PasswordProtectedTransport'
         // Set an array with the possible auth context values: array ('urn:oasis:names:tc:SAML:2.0:ac:classes:Password', 'urn:oasis:names:tc:SAML:2.0:ac:classes:X509'),
         'requestedAuthnContext' => true,
+
+        // Allows the authn comparison parameter to be set, defaults to 'exact' if
+        // the setting is not present.
+        'requestedAuthnContextComparison' => 'exact',
 
         // Indicates if the SP will validate all received xmls.
         // (In order to validate the xml, 'strict' and 'wantXMLValidation' must be true).

--- a/lib/Saml2/AuthnRequest.php
+++ b/lib/Saml2/AuthnRequest.php
@@ -30,7 +30,7 @@ class OneLogin_Saml2_AuthnRequest
      *
      * @param OneLogin_Saml2_Settings $settings Settings
      * @param bool   $forceAuthn When true the AuthNReuqest will set the ForceAuthn='true'
-     * @param bool   $isPassive  When true the AuthNReuqest will set the Ispassive='true' 
+     * @param bool   $isPassive  When true the AuthNReuqest will set the Ispassive='true'
      */
     public function __construct(OneLogin_Saml2_Settings $settings, $forceAuthn = false, $isPassive = false)
     {
@@ -42,7 +42,7 @@ class OneLogin_Saml2_AuthnRequest
 
         $id = OneLogin_Saml2_Utils::generateUniqueID();
         $issueInstant = OneLogin_Saml2_Utils::parseTime2SAML(time());
-        
+
         $nameIDPolicyFormat = $spData['NameIDFormat'];
         if (isset($security['wantNameIdEncrypted']) && $security['wantNameIdEncrypted']) {
             $nameIDPolicyFormat = OneLogin_Saml2_Constants::NAMEID_ENCRYPTED;
@@ -59,7 +59,7 @@ class OneLogin_Saml2_AuthnRequest
             }
             if (isset($organizationData[$lang]['displayname']) && !empty($organizationData[$lang]['displayname'])) {
                 $providerNameStr = <<<PROVIDERNAME
-    ProviderName="{$organizationData[$lang]['displayname']}" 
+    ProviderName="{$organizationData[$lang]['displayname']}"
 PROVIDERNAME;
             }
         }
@@ -82,14 +82,20 @@ ISPASSIVE;
 
         $requestedAuthnStr = '';
         if (isset($security['requestedAuthnContext']) && $security['requestedAuthnContext'] !== false) {
+
+            $authnComparison = 'exact';
+            if (isset($security['requestedAuthnContextComparison'])) {
+                $authnComparison = $security['requestedAuthnContextComparison'];
+            }
+
             if ($security['requestedAuthnContext'] === true) {
                 $requestedAuthnStr = <<<REQUESTEDAUTHN
-    <samlp:RequestedAuthnContext Comparison="exact">
+    <samlp:RequestedAuthnContext Comparison="$authnComparison">
         <saml:AuthnContextClassRef>urn:oasis:names:tc:SAML:2.0:ac:classes:PasswordProtectedTransport</saml:AuthnContextClassRef>
     </samlp:RequestedAuthnContext>
 REQUESTEDAUTHN;
             } else {
-                $requestedAuthnStr .= "    <samlp:RequestedAuthnContext Comparison=\"exact\">\n";
+                $requestedAuthnStr .= "    <samlp:RequestedAuthnContext Comparison=\"$authnComparison\">\n";
                 foreach ($security['requestedAuthnContext'] as $contextValue) {
                     $requestedAuthnStr .= "        <saml:AuthnContextClassRef>".$contextValue."</saml:AuthnContextClassRef>\n";
                 }

--- a/tests/src/OneLogin/Saml2/AuthnRequestTest.php
+++ b/tests/src/OneLogin/Saml2/AuthnRequestTest.php
@@ -20,7 +20,7 @@ class OneLogin_Saml2_AuthnRequestTest extends PHPUnit_Framework_TestCase
     }
 
     /**
-    * Tests the OneLogin_Saml2_AuthnRequest Constructor. 
+    * Tests the OneLogin_Saml2_AuthnRequest Constructor.
     * The creation of a deflated SAML Request
     *
     * @covers OneLogin_Saml2_AuthnRequest
@@ -40,7 +40,7 @@ class OneLogin_Saml2_AuthnRequestTest extends PHPUnit_Framework_TestCase
     }
 
     /**
-    * Tests the OneLogin_Saml2_AuthnRequest Constructor. 
+    * Tests the OneLogin_Saml2_AuthnRequest Constructor.
     * The creation of a deflated SAML Request with AuthNContext
     *
     * @covers OneLogin_Saml2_AuthnRequest
@@ -86,10 +86,18 @@ class OneLogin_Saml2_AuthnRequestTest extends PHPUnit_Framework_TestCase
         $this->assertNotContains('<saml:AuthnContextClassRef>urn:oasis:names:tc:SAML:2.0:ac:classes:PasswordProtectedTransport</saml:AuthnContextClassRef>', $request4);
         $this->assertContains('<saml:AuthnContextClassRef>urn:oasis:names:tc:SAML:2.0:ac:classes:Password</saml:AuthnContextClassRef>', $request4);
         $this->assertContains('<saml:AuthnContextClassRef>urn:oasis:names:tc:SAML:2.0:ac:classes:X509</saml:AuthnContextClassRef>', $request4);
+
+        $settingsInfo['security']['requestedAuthnContextComparison'] = 'minimum';
+        $settings5 = new OneLogin_Saml2_Settings($settingsInfo);
+        $authnRequest5 = new OneLogin_Saml2_AuthnRequest($settings5);
+        $encodedRequest5 = $authnRequest5->getRequest();
+        $decoded5 = base64_decode($encodedRequest5);
+        $request5 = gzinflate($decoded5);
+        $this->assertContains('<samlp:RequestedAuthnContext Comparison="minimum">', $request5);
     }
 
     /**
-    * Tests the OneLogin_Saml2_AuthnRequest Constructor. 
+    * Tests the OneLogin_Saml2_AuthnRequest Constructor.
     * The creation of a deflated SAML Request with ForceAuthn
     *
     * @covers OneLogin_Saml2_AuthnRequest
@@ -120,7 +128,7 @@ class OneLogin_Saml2_AuthnRequestTest extends PHPUnit_Framework_TestCase
     }
 
     /**
-    * Tests the OneLogin_Saml2_AuthnRequest Constructor. 
+    * Tests the OneLogin_Saml2_AuthnRequest Constructor.
     * The creation of a deflated SAML Request with isPassive
     *
     * @covers OneLogin_Saml2_AuthnRequest
@@ -151,7 +159,7 @@ class OneLogin_Saml2_AuthnRequestTest extends PHPUnit_Framework_TestCase
     }
 
     /**
-    * Tests the OneLogin_Saml2_AuthnRequest Constructor. 
+    * Tests the OneLogin_Saml2_AuthnRequest Constructor.
     * The creation of a deflated SAML Request
     *
     * @covers OneLogin_Saml2_AuthnRequest


### PR DESCRIPTION
Adds an extra optional setting to allow the Comparison attribute to be set via the security config.

Existing behaviour is unchanged, a test case has been added and the example settings file updated. The change in logic is at ` lib/Saml2/AuthnRequest.php` line `84`

Also fixed a minor typo in comments and removed extra whitespace.