### PR TITLE
php-saml library needs to trim acs, slo and issuer urls #89

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@
 /tests/build
 /vendor
 /composer.lock
+/.idea

--- a/lib/Saml2/Auth.php
+++ b/lib/Saml2/Auth.php
@@ -396,7 +396,7 @@ class OneLogin_Saml2_Auth
         if (isset($idpData['singleLogoutService']) && isset($idpData['singleLogoutService']['url'])) {
             $url = $idpData['singleLogoutService']['url'];
         }
-        return trim($url);
+        return $url;
     }
 
     /**

--- a/lib/Saml2/Auth.php
+++ b/lib/Saml2/Auth.php
@@ -396,7 +396,7 @@ class OneLogin_Saml2_Auth
         if (isset($idpData['singleLogoutService']) && isset($idpData['singleLogoutService']['url'])) {
             $url = $idpData['singleLogoutService']['url'];
         }
-        return $url;
+        return trim($url);
     }
 
     /**

--- a/lib/Saml2/Response.php
+++ b/lib/Saml2/Response.php
@@ -169,10 +169,11 @@ class OneLogin_Saml2_Response
 
                 // Check destination
                 if ($this->document->documentElement->hasAttribute('Destination')) {
-                    $destination = $this->document->documentElement->getAttribute('Destination');
+                    $destination = trim($this->document->documentElement->getAttribute('Destination'));
                     if (!empty($destination)) {
-                        if (strpos(trim($destination), trim($currentURL)) !== 0) {
+                        if (strpos($destination, $currentURL) !== 0) {
                             $currentURLrouted = OneLogin_Saml2_Utils::getSelfRoutedURLNoQuery();
+
                             if (strpos($destination, $currentURLrouted) !== 0) {
                                 throw new Exception("The response was received at $currentURL instead of $destination");
                             }
@@ -189,7 +190,9 @@ class OneLogin_Saml2_Response
                 // Check the issuers
                 $issuers = $this->getIssuers();
                 foreach ($issuers as $issuer) {
-                    if (empty($issuer) || trim($issuer) !== trim($idPEntityId)) {
+                    $trimmedIssuer = trim($issuer);
+
+                    if (empty($trimmedIssuer) || $trimmedIssuer !== $idPEntityId) {
                         throw new Exception("Invalid issuer in the Assertion/Response");
                     }
                 }

--- a/lib/Saml2/Response.php
+++ b/lib/Saml2/Response.php
@@ -171,7 +171,7 @@ class OneLogin_Saml2_Response
                 if ($this->document->documentElement->hasAttribute('Destination')) {
                     $destination = $this->document->documentElement->getAttribute('Destination');
                     if (!empty($destination)) {
-                        if (strpos($destination, $currentURL) !== 0) {
+                        if (strpos(trim($destination), trim($currentURL)) !== 0) {
                             $currentURLrouted = OneLogin_Saml2_Utils::getSelfRoutedURLNoQuery();
                             if (strpos($destination, $currentURLrouted) !== 0) {
                                 throw new Exception("The response was received at $currentURL instead of $destination");
@@ -189,7 +189,7 @@ class OneLogin_Saml2_Response
                 // Check the issuers
                 $issuers = $this->getIssuers();
                 foreach ($issuers as $issuer) {
-                    if (empty($issuer) || $issuer != $idPEntityId) {
+                    if (empty($issuer) || trim($issuer) !== trim($idPEntityId)) {
                         throw new Exception("Invalid issuer in the Assertion/Response");
                     }
                 }


### PR DESCRIPTION
Trimmed the acs endpoint url from the assertion and from the local machine query.  Trimmed the issuer from the assertion and from the config file settings.  Trimmed the slo url from the config file settings.

If the idp doesn't trim the url's when entered into their admin ui, login fails to work as the acs url in the envelope and the acs url on the server don't match.

Putting a space at the beginning of the acs url in onelogin breaks login. This is fixed with this PR.

The issuer URL seems to be getting trimmed in the OL admin, but I put a trim in anyway to cover using other IDP's. The logout url doesn't redirect at all to the acs endpoint if you put a space in front of the url in the OL admin, and this cannot be fixed by this PR, because in that case the redirect never even occurs and the acs endpoint is never even reached. I put a trim on this too though to be safe. The slo url only comes from settings, not from the idp config. So, doing this we could probably add several more trims to urls coming from config. Skipping that for now.

The primary issue here was to prevent spaces in the OL admin for the acs endpoint breaking login, which is accomplished.

I also made the issuer check a strict type and value equality check changing != to !==. Was there any reason type coercion was intentionally used here?

last thing, modified .gitignore to ignore phpstorm/webstorm/intellij metadata directories.
