### PR TITLE
Issue #101: Raising new SAML_RESPONE_INVALID error when the response fails validation

### DIFF
--- a/lib/Saml2/Auth.php
+++ b/lib/Saml2/Auth.php
@@ -120,6 +120,10 @@ class OneLogin_Saml2_Auth
             } else {
                 $this->_errors[] = 'invalid_response';
                 $this->_errorReason = $response->getError();
+                throw new OneLogin_Saml2_Error(
+                  'SAML Response invalid: ' . $this->_errorReason,
+                  OneLogin_Saml2_Error::SAML_RESPONSE_INVALID
+                );
             }
         } else {
             $this->_errors[] = 'invalid_binding';

--- a/lib/Saml2/Error.php
+++ b/lib/Saml2/Error.php
@@ -21,6 +21,7 @@ class OneLogin_Saml2_Error extends Exception
     const SAML_LOGOUTREQUEST_INVALID = 10;
     const SAML_LOGOUTRESPONSE_INVALID  = 11;
     const SAML_SINGLE_LOGOUT_NOT_SUPPORTED = 12;
+    const SAML_RESPONSE_INVALID = 13;
     
     /**
      * Constructor


### PR DESCRIPTION
Unsure how you feel about a dynamic error message from errorReason. 