### PR TITLE
Fix/namespace requirement adfs

### DIFF
--- a/lib/Saml2/LogoutRequest.php
+++ b/lib/Saml2/LogoutRequest.php
@@ -61,6 +61,14 @@ class OneLogin_Saml2_LogoutRequest
             if (isset($security['nameIdEncrypted']) && $security['nameIdEncrypted']) {
                 $cert = $idpData['x509cert'];
             }
+            
+            $namespace = null;
+            $namespaceIssuer = '';
+            if (isset($idpData['singleLogoutService']['namespace'])) {
+                $namespace = $idpData['singleLogoutService']['namespace'];
+                $namespaceIssuer = ' xmlns:saml="' . $namespace . '"';
+            }
+            
 
             if (!empty($nameId)) {
                 $nameIdFormat = $spData['NameIDFormat'];
@@ -88,7 +96,7 @@ class OneLogin_Saml2_LogoutRequest
     Version="2.0"
     IssueInstant="{$issueInstant}"
     Destination="{$idpData['singleLogoutService']['url']}">
-    <saml:Issuer>{$spData['entityId']}</saml:Issuer>
+    <saml:Issuer{$namespaceIssuer}>{$spData['entityId']}</saml:Issuer>
     {$nameIdObj}
     {$sessionIndexStr}
 </samlp:LogoutRequest>

--- a/lib/Saml2/LogoutRequest.php
+++ b/lib/Saml2/LogoutRequest.php
@@ -83,7 +83,8 @@ class OneLogin_Saml2_LogoutRequest
                 $nameId,
                 $spNameQualifier,
                 $nameIdFormat,
-                $cert
+                $cert,
+                $namespace
             );
 
             $sessionIndexStr = isset($sessionIndex) ? "<samlp:SessionIndex>{$sessionIndex}</samlp:SessionIndex>" : "";

--- a/lib/Saml2/Utils.php
+++ b/lib/Saml2/Utils.php
@@ -692,14 +692,15 @@ class OneLogin_Saml2_Utils
     /**
      * Generates a nameID.
      *
-     * @param string $value  fingerprint
-     * @param string $spnq   SP Name Qualifier
-     * @param string $format SP Format
-     * @param string $cert   IdP Public cert to encrypt the nameID
+     * @param string $value     fingerprint
+     * @param string $spnq      SP Name Qualifier
+     * @param string $format    SP Format
+     * @param string $cert      IdP Public cert to encrypt the nameID
+     * @param string $namespace Namespace for logout request
      *
      * @return string $nameIDElement DOMElement | XMLSec nameID
      */
-    public static function generateNameId($value, $spnq, $format, $cert = null)
+    public static function generateNameId($value, $spnq, $format, $cert = null, $namespace = null)
     {
 
         $doc = new DOMDocument();
@@ -708,6 +709,11 @@ class OneLogin_Saml2_Utils
         if (isset($spnq)) {
             $nameId->setAttribute('SPNameQualifier', $spnq);
         }
+        
+        if ($namespace !== null) {
+            $nameId->setAttribute('xmlns:saml', $namespace);
+        }
+        
         $nameId->setAttribute('Format', $format);
         $nameId->appendChild($doc->createTextNode($value));
 


### PR DESCRIPTION
While working with a client there was this specific requirement the logout request needed. They are using ADFS which requires `xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion"` on the issuer and nameid tags. E.g.

```
<saml:Issuer xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion">ENTITYID</saml:Issuer>
<saml:NameID xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion" Format="urn:oasis:names:tc:SAML:2.0:nameid-format:persistent">NAMEID</saml:NameID>
```

I've added a new config option to the idp data so that other users can specify different namespaces if needed.

I'm very new to SAML and SSO so I might not of fully understood how your package works, if it can already cope with this.

Thanks
Chris