### PR TITLE
Handles empty SignedInfo Reference for a referred full signed Response.

### DIFF
--- a/lib/Saml2/Response.php
+++ b/lib/Saml2/Response.php
@@ -577,6 +577,10 @@ class OneLogin_Saml2_Response
             $assertionReferenceNode = $xpath->query($signatureQuery)->item(0);
             if ($assertionReferenceNode) {
                 $id = substr($assertionReferenceNode->attributes->getNamedItem('URI')->nodeValue, 1);
+                if (empty($id)) {
+                    $response = $xpath->query('/samlp:Response')->item(0);
+                    $id = $response->attributes->getNamedItem('ID')->nodeValue;
+                }
                 $nameQuery = "/samlp:Response[@ID='$id']/".($this->encrypted? "saml:EncryptedAssertion/" : "")."saml:Assertion" . $assertionXpath;
             } else {
                 $nameQuery = "/samlp:Response/".($this->encrypted? "saml:EncryptedAssertion/" : "")."saml:Assertion" . $assertionXpath;

--- a/lib/Saml2/Utils.php
+++ b/lib/Saml2/Utils.php
@@ -991,14 +991,18 @@ class OneLogin_Saml2_Utils
         }
 
         # Check if Reference URI is empty
-        $emptyUri = false;
+        $signatureElem = null;
+        $referenceElem = null;
         try {
             $signatureElems = $dom->getElementsByTagName('Signature');
             foreach ($signatureElems as $signatureElem) {
                 $referenceElems = $dom->getElementsByTagName('Reference');
                 if (count($referenceElems) > 0) {
                     $referenceElem = $referenceElems->item(0);
-                    $emptyUri = ($referenceElem->getAttribute('URI') == '');
+                    if ($referenceElem->getAttribute('URI') == '') {
+                        break;
+                    }
+                    $referenceElem = null;
                 }
             }
         } catch (Exception $e) {
@@ -1033,7 +1037,7 @@ class OneLogin_Saml2_Utils
                 $objKey->loadKey($cert, false, true);
                 if ($objXMLSecDSig->verify($objKey) === 1) {
                     return true;
-                } else if (!$emptyUri) {
+                } else if (!$referenceElem) {
                     return false;
                 }
             } else {
@@ -1045,14 +1049,14 @@ class OneLogin_Saml2_Utils
                     $objKey->loadKey($domCert, false, true);
                     if ($objXMLSecDSig->verify($objKey) === 1) {
                         return true;
-                    } else if (!$emptyUri) {
+                    } else if (!$referenceElem) {
                         return false;
                     }
                 }
             }
 
             $referenceElem->setAttribute('URI', '#'.$signatureElem->parentNode->getAttribute('ID'));
-            $emptyUri = false;
+            $referenceElem = null;
         }
     }
 }

--- a/lib/Saml2/Utils.php
+++ b/lib/Saml2/Utils.php
@@ -999,7 +999,7 @@ class OneLogin_Saml2_Utils
                 $referenceElems = $dom->getElementsByTagName('Reference');
                 if (count($referenceElems) > 0) {
                     $referenceElem = $referenceElems->item(0);
-                    if ($referenceElem->getAttribute('URI') == '' && $signatureElem->parentNode) {
+                    if ($referenceElem->getAttribute('URI') == '') {
                         break;
                     }
                     $referenceElem = null;
@@ -1055,7 +1055,9 @@ class OneLogin_Saml2_Utils
                 }
             }
 
-            $referenceElem->setAttribute('URI', '#'.$signatureElem->parentNode->getAttribute('ID'));
+            if ($signatureElem->parentNode) {
+                $referenceElem->setAttribute('URI', '#'.$signatureElem->parentNode->getAttribute('ID'));
+            }
             $referenceElem = null;
         }
     }

--- a/lib/Saml2/Utils.php
+++ b/lib/Saml2/Utils.php
@@ -999,7 +999,7 @@ class OneLogin_Saml2_Utils
                 $referenceElems = $dom->getElementsByTagName('Reference');
                 if (count($referenceElems) > 0) {
                     $referenceElem = $referenceElems->item(0);
-                    if ($referenceElem->getAttribute('URI') == '') {
+                    if ($referenceElem->getAttribute('URI') == '' && $signatureElem->parentNode) {
                         break;
                     }
                     $referenceElem = null;


### PR DESCRIPTION
When the SignedInfo Reference has a blank URI, we should NOT inject one if the full response is signed because that breaks the signature validation in some cases. In the other hand, by not doing that everything that expected the URI to not be empty will break because there's no URI to reference while extracting fields from the response. So we need to fallback on the response's actual ID.
For the case where the SignedInfo SHOULD have a URI pointing to the response but there's none, we just retry validating the signature with the injected URI, preserving the behavior with a reasonable performance penalty.