### PR TITLE
Issue 102 Encryption is enabled in the metadata even though it's disa…

### DIFF
--- a/docs/Saml2/classes/OneLogin_Saml2_Metadata.html
+++ b/docs/Saml2/classes/OneLogin_Saml2_Metadata.html
@@ -260,7 +260,7 @@ The same cert will be used for sign/encrypt</span><pre>addX509KeyDescriptors</pr
                         <div class="element clickable method public  method_addX509KeyDescriptors" data-toggle="collapse" data-target=".method_addX509KeyDescriptors .collapse">
                             <h2>Adds the x509 descriptors (sign/encriptation) to the metadata
 The same cert will be used for sign/encrypt</h2>
-                            <pre>addX509KeyDescriptors(string $metadata, string $cert) : string</pre>
+                            <pre>addX509KeyDescriptors(string $metadata, string $cert, boolean $wants_encrypted) : string</pre>
                             <div class="labels">
                                                                 <span class="label">static</span>                                                                                                                            </div>
                             <div class="row collapse">
@@ -285,6 +285,10 @@ The same cert will be used for sign/encrypt</h2>
                                                                                     <div class="subelement argument">
                                                 <h4>$cert</h4>
                                                 <code>string</code><p><p>x509 cert</p></p>
+                                            </div>
+                                            <div class="subelement argument">
+                                                <h4>$wants_encrypted</h4>
+                                                <code>boolean</code><p><p>Whether to include the KeyDescriptor for encryption</p></p>
                                             </div>
                                                                             
                                                                             <h3>Response</h3>

--- a/lib/Saml2/Metadata.php
+++ b/lib/Saml2/Metadata.php
@@ -133,10 +133,11 @@ METADATA_TEMPLATE;
      *
      * @param string $metadata SAML Metadata XML
      * @param string $cert     x509 cert
+     * @param boolean $wants_encrypted Whether to include the KeyDescriptor for encryption
      *
      * @return string Metadata with KeyDescriptors
      */
-    public static function addX509KeyDescriptors($metadata, $cert)
+    public static function addX509KeyDescriptors($metadata, $cert, $wants_encrypted = true)
     {
         $xml = new DOMDocument();
         $xml->preserveWhiteSpace = false;
@@ -163,16 +164,20 @@ METADATA_TEMPLATE;
 
         $SPSSODescriptor = $xml->getElementsByTagName('SPSSODescriptor')->item(0);
         $SPSSODescriptor->insertBefore($keyDescriptor->cloneNode(), $SPSSODescriptor->firstChild);
-        $SPSSODescriptor->insertBefore($keyDescriptor->cloneNode(), $SPSSODescriptor->firstChild);
+        if ($wants_encrypted === true) {
+            $SPSSODescriptor->insertBefore($keyDescriptor->cloneNode(), $SPSSODescriptor->firstChild);
+        }
 
         $signing = $xml->getElementsByTagName('KeyDescriptor')->item(0);
         $signing->setAttribute('use', 'signing');
-
-        $encryption = $xml->getElementsByTagName('KeyDescriptor')->item(1);
-        $encryption->setAttribute('use', 'encryption');
-
         $signing->appendChild($keyInfo);
-        $encryption->appendChild($keyInfo->cloneNode(true));
+
+        if ($wants_encrypted === true) {
+            $encryption = $xml->getElementsByTagName('KeyDescriptor')->item(1);
+            $encryption->setAttribute('use', 'encryption');
+
+            $encryption->appendChild($keyInfo->cloneNode(true));
+        }
 
         return $xml->saveXML();
     }

--- a/lib/Saml2/Settings.php
+++ b/lib/Saml2/Settings.php
@@ -671,7 +671,11 @@ class OneLogin_Saml2_Settings
         $cert = $this->getSPcert();
 
         if (!empty($cert)) {
-            $metadata = OneLogin_Saml2_Metadata::addX509KeyDescriptors($metadata, $cert);
+            $metadata = OneLogin_Saml2_Metadata::addX509KeyDescriptors(
+                $metadata,
+                $cert,
+                $this->_security['wantNameIdEncrypted'] || $this->_security['wantAssertionsEncrypted']
+            );
         }
 
         //Sign Metadata

--- a/tests/src/OneLogin/Saml2/MetadataTest.php
+++ b/tests/src/OneLogin/Saml2/MetadataTest.php
@@ -132,6 +132,16 @@ class OneLogin_Saml2_MetadataTest extends PHPUnit_Framework_TestCase
         $this->assertContains('<md:KeyDescriptor use="signing"', $metadataWithDescriptors);
         $this->assertContains('<md:KeyDescriptor use="encryption"', $metadataWithDescriptors);
 
+        $metadataWithDescriptors = OneLogin_Saml2_Metadata::addX509KeyDescriptors($metadata, $cert, false);
+
+        $this->assertContains('<md:KeyDescriptor use="signing"', $metadataWithDescriptors);
+        $this->assertNotContains('<md:KeyDescriptor use="encryption"', $metadataWithDescriptors);
+
+        $metadataWithDescriptors = OneLogin_Saml2_Metadata::addX509KeyDescriptors($metadata, $cert, 'foobar');
+
+        $this->assertContains('<md:KeyDescriptor use="signing"', $metadataWithDescriptors);
+        $this->assertNotContains('<md:KeyDescriptor use="encryption"', $metadataWithDescriptors);
+
         try {
             $signedMetadata2 = OneLogin_Saml2_Metadata::addX509KeyDescriptors('', $cert);
             $this->assertFalse(true);


### PR DESCRIPTION
This pull should resolve issue #102 using the existing want*Encrypted settings values to determine whether an encryption KeyDescriptor is necessary in the Service Provider metadata.

* Pass the boolean and combination of the security settings for
wantNameIdEncrypted and wantAssertionsEncrypted to the
OneLogin_Saml2_Metadata::addX509KeyDescriptors method so the method can
determine whether an encryption KeyDescriptor is necessary. If both settings are
false then an encryption KeyDescriptor will be omitted.
* Updated unit tests to verify that encryption KeyDescriptor is not added if
want_encrypted is not passed as true.
* A potential issue with this change is that since the default values for
wantNameIdEncrypted and wantAssertionsEncrypted are false, if a Service Provider
is setup so that they do not set either value to true and have a certificate set
in their settings the metadata returned by their service provider will change
with this code change. This could be a breaking change in this case.

Issue #102