### PR TITLE
Fixing getter for lastRequestID parameter in OneLogin_Saml2_Auth class

### DIFF
--- a/lib/Saml2/Auth.php
+++ b/lib/Saml2/Auth.php
@@ -435,7 +435,7 @@ class OneLogin_Saml2_Auth
      */
     public function getLastRequestID()
     {
-        return $_lastRequestID;
+        return $this->_lastRequestID;
     }
 
     /**


### PR DESCRIPTION
There is a bug in OneLogin_Saml2_Auth::getLastRequestID() method. It does not use $this to reference value of class. Here is one-liner fix for it