### PR TITLE
Add note for "wantAssertionsEncrypted"

### DIFF
--- a/README.md
+++ b/README.md
@@ -397,6 +397,10 @@ $advancedSettings = array (
         'wantMessagesSigned' => false,
 
         // Indicates a requirement for the <saml:Assertion> elements received by
+        // this SP to be encrypted. [Metadata of the SP will offer this info]
+        'wantAssertionsEncrypted' => false,
+         
+        // Indicates a requirement for the <saml:Assertion> elements received by
         // this SP to be signed. [Metadata of the SP will offer this info]
         'wantAssertionsSigned' => false,
 

--- a/README.md
+++ b/README.md
@@ -397,7 +397,7 @@ $advancedSettings = array (
         'wantMessagesSigned' => false,
 
         // Indicates a requirement for the <saml:Assertion> elements received by
-        // this SP to be encrypted. [Metadata of the SP will offer this info]
+        // this SP to be encrypted.
         'wantAssertionsEncrypted' => false,
          
         // Indicates a requirement for the <saml:Assertion> elements received by

--- a/advanced_settings_example.php
+++ b/advanced_settings_example.php
@@ -39,6 +39,10 @@ $advancedSettings = array (
         'wantMessagesSigned' => false,
 
         // Indicates a requirement for the <saml:Assertion> elements received by
+        // this SP to be encrypted. [Metadata of the SP will offer this info]
+        'wantAssertionsEncrypted' => false,
+
+        // Indicates a requirement for the <saml:Assertion> elements received by
         // this SP to be signed.        [The Metadata of the SP will offer this info]
         'wantAssertionsSigned' => false,
 

--- a/advanced_settings_example.php
+++ b/advanced_settings_example.php
@@ -39,7 +39,7 @@ $advancedSettings = array (
         'wantMessagesSigned' => false,
 
         // Indicates a requirement for the <saml:Assertion> elements received by
-        // this SP to be encrypted. [Metadata of the SP will offer this info]
+        // this SP to be encrypted.
         'wantAssertionsEncrypted' => false,
 
         // Indicates a requirement for the <saml:Assertion> elements received by


### PR DESCRIPTION
I'm not that big into SAML myself so please excuse if this is not the absolute correct wording here.

This just got me spending quite some hours and wondering why I couldn't connect to testshib.org, turned out: I have to indicate that I want the message encrypted but setting "wantNameIdEncrypted" would trigger:

> Unsigned SAML Response that contains a signed and encrypted Assertion with encrypted nameId is not supported

Setting this undocumented config switch that I found in the source code made it work :see_no_evil: