### PR TITLE
PHP7 production settings compiles out assert(), throw an exception explicitly

### DIFF
--- a/lib/Saml2/Auth.php
+++ b/lib/Saml2/Auth.php
@@ -102,7 +102,10 @@ class OneLogin_Saml2_Auth
      */
     public function setStrict($value)
     {
-        assert('is_bool($value)');
+        if (! (is_bool($value))) {
+            throw new Exception('Invalid value passed to setStrict()');
+        }
+
         $this->_settings->setStrict($value);
     }
 

--- a/lib/Saml2/Settings.php
+++ b/lib/Saml2/Settings.php
@@ -1,5 +1,5 @@
 <?php
- 
+
 /**
  * Configuration of the OneLogin PHP Toolkit
  *
@@ -15,7 +15,7 @@ class OneLogin_Saml2_Settings
     private $_paths = array();
 
     /**
-     * Strict. If active, PHP Toolkit will reject unsigned or unencrypted messages 
+     * Strict. If active, PHP Toolkit will reject unsigned or unencrypted messages
      * if it expects them signed or encrypted. If not, the messages will be accepted
      * and some security issues will be also relaxed.
      *
@@ -209,7 +209,7 @@ class OneLogin_Saml2_Settings
      * Loads settings info from a settings Array
      *
      * @param array $settings SAML Toolkit Settings
-     * 
+     *
      * @return bool True if the settings info is valid
      */
     private function _loadSettingsFromArray($settings)
@@ -698,7 +698,7 @@ class OneLogin_Saml2_Settings
                         OneLogin_Saml2_Error::PRIVATE_KEY_FILE_NOT_FOUND
                     );
                 }
-                
+
                 if (!$certMetadata) {
                     throw new OneLogin_Saml2_Error(
                         'Public cert file not found.',
@@ -719,7 +719,7 @@ class OneLogin_Saml2_Settings
 
                 $keyMetadataFile = $this->_paths['cert'].$keyFileName;
                 $certMetadataFile = $this->_paths['cert'].$certFileName;
-            
+
 
                 if (!file_exists($keyMetadataFile)) {
                     throw new OneLogin_Saml2_Error(
@@ -728,7 +728,7 @@ class OneLogin_Saml2_Settings
                         array($keyMetadataFile)
                     );
                 }
-                
+
                 if (!file_exists($certMetadataFile)) {
                     throw new OneLogin_Saml2_Error(
                         'Public cert file not found: %s',
@@ -835,7 +835,9 @@ class OneLogin_Saml2_Settings
      */
     public function setStrict($value)
     {
-        assert('is_bool($value)');
+        if (! (is_bool($value))) {
+            throw new Exception('Invalid value passed to setStrict()');
+        }
 
         $this->_strict = $value;
     }

--- a/tests/src/OneLogin/Saml2/AuthTest.php
+++ b/tests/src/OneLogin/Saml2/AuthTest.php
@@ -23,7 +23,7 @@ class OneLogin_Saml2_AuthTest extends PHPUnit_Framework_TestCase
     /**
     * Tests the getSettings method of the OneLogin_Saml2_Auth class
     * Build a OneLogin_Saml2_Settings object with a setting array
-    * and compare the value returned from the method of the 
+    * and compare the value returned from the method of the
     * $auth object
     *
     * @covers OneLogin_Saml2_Auth::getSettings
@@ -93,7 +93,7 @@ class OneLogin_Saml2_AuthTest extends PHPUnit_Framework_TestCase
     * @covers OneLogin_Saml2_Auth::getErrors
     * @covers OneLogin_Saml2_Auth::getSessionIndex
     * @covers OneLogin_Saml2_Auth::getSessionExpiration
-    * @covers OneLogin_Saml2_Auth::getLastErrorReason    
+    * @covers OneLogin_Saml2_Auth::getLastErrorReason
     */
     public function testProcessResponseInvalid()
     {
@@ -150,7 +150,7 @@ class OneLogin_Saml2_AuthTest extends PHPUnit_Framework_TestCase
     *
     * @covers OneLogin_Saml2_Auth::processResponse
     * @covers OneLogin_Saml2_Auth::isAuthenticated
-    * @covers OneLogin_Saml2_Auth::getAttributes    
+    * @covers OneLogin_Saml2_Auth::getAttributes
     * @covers OneLogin_Saml2_Auth::getAttribute
     * @covers OneLogin_Saml2_Auth::getNameId
     * @covers OneLogin_Saml2_Auth::getSessionIndex
@@ -178,7 +178,7 @@ class OneLogin_Saml2_AuthTest extends PHPUnit_Framework_TestCase
 
     /**
     * Tests the redirectTo method of the OneLogin_Saml2_Auth class
-    * (phpunit raises an exception when a redirect is executed, the 
+    * (phpunit raises an exception when a redirect is executed, the
     * exception is catched and we check that the targetURL is correct)
     * Case redirect without url parameter
     *
@@ -205,7 +205,7 @@ class OneLogin_Saml2_AuthTest extends PHPUnit_Framework_TestCase
 
     /**
     * Tests the redirectTo method of the OneLogin_Saml2_Auth class
-    * (phpunit raises an exception when a redirect is executed, the 
+    * (phpunit raises an exception when a redirect is executed, the
     * exception is catched and we check that the targetURL is correct)
     * Case redirect with url parameter
     *
@@ -358,7 +358,7 @@ class OneLogin_Saml2_AuthTest extends PHPUnit_Framework_TestCase
 
     /**
     * Tests the processSLO method of the OneLogin_Saml2_Auth class
-    * Case Valid Logout Response, validating deleting the local session  
+    * Case Valid Logout Response, validating deleting the local session
     *
     * @covers OneLogin_Saml2_Auth::processSLO
     */
@@ -482,7 +482,7 @@ class OneLogin_Saml2_AuthTest extends PHPUnit_Framework_TestCase
     *
     * @covers OneLogin_Saml2_Auth::processSLO
     */
-    
+
     public function testProcessSLORequestNotOnOrAfterFailed()
     {
         $message = file_get_contents(TEST_ROOT . '/data/logout_requests/invalids/not_after_failed.xml.base64');
@@ -741,7 +741,7 @@ class OneLogin_Saml2_AuthTest extends PHPUnit_Framework_TestCase
 
     /**
     * Tests the login method of the OneLogin_Saml2_Auth class
-    * Case Login with relayState. An AuthnRequest is built. GET with SAMLRequest, 
+    * Case Login with relayState. An AuthnRequest is built. GET with SAMLRequest,
     * and RelayState. A redirection is executed
     *
     * @covers OneLogin_Saml2_Auth::login
@@ -880,7 +880,7 @@ class OneLogin_Saml2_AuthTest extends PHPUnit_Framework_TestCase
             $request = gzinflate($decoded);
             $this->assertNotContains('ForceAuthn="true"', $request);
         }
-        
+
         try {
             // The Header of the redirect produces an Exception
             $returnTo = 'http://example.com/returnto';
@@ -962,7 +962,7 @@ class OneLogin_Saml2_AuthTest extends PHPUnit_Framework_TestCase
             $request = gzinflate($decoded);
             $this->assertNotContains('IsPassive="true"', $request);
         }
-        
+
         try {
             // The Header of the redirect produces an Exception
             $returnTo = 'http://example.com/returnto';
@@ -1040,7 +1040,7 @@ class OneLogin_Saml2_AuthTest extends PHPUnit_Framework_TestCase
             $request = gzinflate($decoded);
             $this->assertNotContains('<samlp:NameIDPolicy', $request);
         }
-        
+
         try {
             // The Header of the redirect produces an Exception
             $returnTo = 'http://example.com/returnto';
@@ -1285,7 +1285,7 @@ class OneLogin_Saml2_AuthTest extends PHPUnit_Framework_TestCase
 
     /**
     * Tests the logout method of the OneLogin_Saml2_Auth class
-    * Case IdP no SLO endpoint. 
+    * Case IdP no SLO endpoint.
     *
     * @covers OneLogin_Saml2_Auth::logout
     */
@@ -1335,7 +1335,7 @@ class OneLogin_Saml2_AuthTest extends PHPUnit_Framework_TestCase
             $auth->setStrict('a');
             $this->assertTrue(false);
         } catch (Exception $e) {
-            $this->assertContains('Assertion "is_bool($value)" failed', $e->getMessage());
+            $this->assertContains('Invalid value passed to setStrict()', $e->getMessage());
         }
     }
 

--- a/tests/src/OneLogin/Saml2/SettingsTest.php
+++ b/tests/src/OneLogin/Saml2/SettingsTest.php
@@ -7,7 +7,7 @@ class OneLogin_Saml2_SettingsTest extends PHPUnit_Framework_TestCase
 {
 
     /**
-    * Tests the OneLogin_Saml2_Settings Constructor. 
+    * Tests the OneLogin_Saml2_Settings Constructor.
     * Case load setting from array
     *
     * @covers OneLogin_Saml2_Settings
@@ -43,7 +43,7 @@ class OneLogin_Saml2_SettingsTest extends PHPUnit_Framework_TestCase
     }
 
     /**
-    * Tests the OneLogin_Saml2_Settings Constructor. 
+    * Tests the OneLogin_Saml2_Settings Constructor.
     * Case load setting from OneLogin_Saml_Settings's object
     *
     * @covers OneLogin_Saml2_Settings
@@ -60,7 +60,7 @@ class OneLogin_Saml2_SettingsTest extends PHPUnit_Framework_TestCase
     }
 
     /**
-    * Tests the OneLogin_Saml2_Settings Constructor. 
+    * Tests the OneLogin_Saml2_Settings Constructor.
     * Case load setting from file
     *
     * @covers OneLogin_Saml2_Settings
@@ -740,7 +740,7 @@ class OneLogin_Saml2_SettingsTest extends PHPUnit_Framework_TestCase
             $settings->setStrict('a');
             $this->assertTrue(false);
         } catch (Exception $e) {
-            $this->assertContains('Assertion "is_bool($value)" failed', $e->getMessage());
+            $this->assertContains('Invalid value passed to setStrict()', $e->getMessage());
         }
     }
 


### PR DESCRIPTION
I'm packaging this for Fedora at present.

One thing the Fedora Rawhide build highlighted was the tests failing on a php.ini-production setup.

As per the RFC that implemented the PHP7 Exception framework assert() should not be used to validate things in a production runtime:

https://wiki.php.net/rfc/expectations#production_time

It should be limited to development/debug scenarios.

A quick flick through other assert() usage in lib/* looks like exceptions should be still raised by things like XML DOM manipulators with the assert() there compiled out, or things like a $msg will just get silently casted if not already a string. 

However the is_bool() check for setStrict() doesn't happen under php.ini-production as the assert for it is compiled out. This PR turns that specific check into a specific is_bool conditional check and throws an exception if it's not true one, as per the runtime zend.assertions=1 behaviour for the development config and as the tests expect to happen.

