### PR TITLE
Adding on/off settings for compression of SAML Requests and responses.

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,10 +11,10 @@ Why add SAML support to my software?
 ------------------------------------
 
 SAML is an XML-based standard for web browser single sign-on and is defined by
-the OASIS Security Services Technical Committee. The standard has been around 
+the OASIS Security Services Technical Committee. The standard has been around
 since 2002, but lately it is becoming popular due its advantages:
 
- * **Usability** - One-click access from portals or intranets, deep linking, 
+ * **Usability** - One-click access from portals or intranets, deep linking,
    password elimination and automatically renewing sessions make life
    easier for the user.
  * **Security** - Based on strong digital signatures for authentication and
@@ -27,7 +27,7 @@ since 2002, but lately it is becoming popular due its advantages:
  * **IT Friendly** - SAML simplifies life for IT because it centralizes
    authentication, provides greater visibility and makes directory
    integration easier.
- * **Opportunity** - B2B cloud vendor should support SAML to facilitate the 
+ * **Opportunity** - B2B cloud vendor should support SAML to facilitate the
    integration of their product.
 
 
@@ -52,7 +52,7 @@ Key features:
  * **saml2int** - Implements the SAML 2.0 Web Browser SSO Profile.
  * **Session-less** - Forget those common conflicts between the SP and
    the final app, the toolkit delegate session in the final app.
- * **Easy to use** - Programmer will be allowed to code high-level and 
+ * **Easy to use** - Programmer will be allowed to code high-level and
    low-level programming, 2 easy to use APIs are available.
  * **Tested** - Thoroughly tested.
  * **Popular** - OneLogin's customers use it. Many PHP SAML plugins uses it.
@@ -80,7 +80,7 @@ The toolkit is hosted on github. You can download it from:
 
  * Lastest release: https://github.com/onelogin/php-saml/releases/latest
  * Master repo: https://github.com/onelogin/php-saml/tree/master
- 
+
 Copy the core of the library inside the php application. (each application has its
 structure so take your time to locate the PHP SAML toolkit in the best place).
 See the "Guide to add SAML support to my app" to know how.
@@ -134,7 +134,7 @@ start, for example to use the static method getSelfURLNoQuery use:
 Security warning
 ----------------
 
-In production, the `strict` parameter **MUST** be set as `"true"`. Otherwise 
+In production, the `strict` parameter **MUST** be set as `"true"`. Otherwise
 your environment is not secure and will be exposed to attacks.
 
 
@@ -221,10 +221,10 @@ and support multiple languages.
 
 * `settings_example_example.php` - A template to be used in order to create a
   settings.php file which contains the basic configuration info of the toolkit.
-* `advanced_settings_example.php` - A template to be used in order to create a 
+* `advanced_settings_example.php` - A template to be used in order to create a
   advanced_settings.php file which contains extra configuration info related to
   the security, the contact person, and the organization associated to the SP.
-* `_toolkit_loader.php` - This file load the toolkit libraries (The SAML2 lib). 
+* `_toolkit_loader.php` - This file load the toolkit libraries (The SAML2 lib).
 * `compatibility` - Import that file to make compatible your old code with the
   new toolkit (loads the SAML library).
 
@@ -232,26 +232,26 @@ and support multiple languages.
 #### Miscellaneous ####
 
 * `tests/` - Contains the unit test of the toolkit.
-* `demo1/` - Contains an example of a simple PHP app with SAML support. 
+* `demo1/` - Contains an example of a simple PHP app with SAML support.
   Read the `Readme.txt` inside for more info.
 * `demo2/` - Contains another example.
 * `demo-old/` - Contains an example that uses the code of the older version of the
   the toolkit to demonstrate the backwards compatibility.
- 
+
 
 ### How it works ###
 
 #### Settings ####
 
 First of all we need to configure the toolkit. The SP's info, the IdP's info,
-and in some cases, configure advanced security issues like signatures and 
+and in some cases, configure advanced security issues like signatures and
 encryption.
 
 There are two ways to provide the settings information:
 
  * Use a `settings.php` file that we should locate at the base folder of the
    toolkit.
- * Use an array with the setting data and provide it directly to the 
+ * Use an array with the setting data and provide it directly to the
    constructor of the class.
 
 
@@ -262,7 +262,7 @@ file, rename and edit it.
 <?php
 
 $settings = array (
-    // If 'strict' is True, then the PHP Toolkit will reject unsigned 
+    // If 'strict' is True, then the PHP Toolkit will reject unsigned
     // or unencrypted messages if it expects them to be signed or encrypted.
     // Also it will reject the messages if the SAML standard is not strictly
     // followed: Destination, NameId, Conditions ... are validated too.
@@ -281,7 +281,7 @@ $settings = array (
             // URL Location where the <Response> from the IdP will be returned
             'url' => '',
             // SAML protocol binding to be used when returning the <Response>
-            // message. OneLogin Toolkit supports this endpoint for the 
+            // message. OneLogin Toolkit supports this endpoint for the
             // HTTP-POST binding only.
             'binding' => 'urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST',
         ),
@@ -312,7 +312,7 @@ $settings = array (
         'entityId' => '',
         // SSO endpoint info of the IdP. (Authentication Request protocol)
         'singleSignOnService' => array (
-            // URL Target of the IdP where the Authentication Request Message 
+            // URL Target of the IdP where the Authentication Request Message
             // will be sent.
             'url' => '',
             // SAML protocol binding to be used when returning the <Response>
@@ -332,7 +332,7 @@ $settings = array (
         // Public x509 certificate of the IdP
         'x509cert' => '',
         /*
-         *  Instead of use the whole x509cert you can use a fingerprint in order to 
+         *  Instead of use the whole x509cert you can use a fingerprint in order to
          *  validate a SAMLResponse.
          *  (openssl x509 -noout -fingerprint -in "idp.crt" to generate it,
          *   or add for example the -sha256 , -sha384 or -sha512 parameter)
@@ -340,7 +340,7 @@ $settings = array (
          *  If a fingerprint is provided, then the certFingerprintAlgorithm is required in order to
          *  let the toolkit know which algorithm was used. Possible values: sha1, sha256, sha384 or sha512
          *  'sha1' is the default value.
-         * 
+         *
          *  Notice that if you want to validate any SAML Message sent by the HTTP-Redirect binding, you
          *  will need to provide the whole x509cert.
          */
@@ -349,9 +349,9 @@ $settings = array (
     ),
 );
 ```
-In addition to the required settings data (IdP, SP), there is extra 
+In addition to the required settings data (IdP, SP), there is extra
 information that could be defined. In the same way that a template exists
-for the basic info, there is a template for that advanced info located 
+for the basic info, there is a template for that advanced info located
 at the base folder of the toolkit and named `advanced_settings_example.php`
 that you can copy and rename it as `advanced_settings.php`
 
@@ -360,6 +360,11 @@ that you can copy and rename it as `advanced_settings.php`
 
 $advancedSettings = array (
 
+    // Compression settings
+    'compress' => array (
+        'requests' => true,
+        'responses' => true
+    ),
     // Security settings
     'security' => array (
 
@@ -369,15 +374,15 @@ $advancedSettings = array (
         // will be encrypted.
         'nameIdEncrypted' => false,
 
-        // Indicates whether the <samlp:AuthnRequest> messages sent by this SP 
+        // Indicates whether the <samlp:AuthnRequest> messages sent by this SP
         // will be signed.  [Metadata of the SP will offer this info]
         'authnRequestsSigned' => false,
 
-        // Indicates whether the <samlp:logoutRequest> messages sent by this SP 
+        // Indicates whether the <samlp:logoutRequest> messages sent by this SP
         // will be signed.
         'logoutRequestSigned' => false,
 
-        // Indicates whether the <samlp:logoutResponse> messages sent by this SP 
+        // Indicates whether the <samlp:logoutResponse> messages sent by this SP
         // will be signed.
         'logoutResponseSigned' => false,
 
@@ -399,12 +404,12 @@ $advancedSettings = array (
         // Indicates a requirement for the <saml:Assertion> elements received by
         // this SP to be encrypted.
         'wantAssertionsEncrypted' => false,
-         
+
         // Indicates a requirement for the <saml:Assertion> elements received by
         // this SP to be signed. [Metadata of the SP will offer this info]
         'wantAssertionsSigned' => false,
 
-        // Indicates a requirement for the NameID element on the SAMLResponse 
+        // Indicates a requirement for the NameID element on the SAMLResponse
         // received by this SP to be present.
         'wantNameId' => true,
 
@@ -457,6 +462,11 @@ $advancedSettings = array (
 );
 ```
 
+The compression settings allow you to instruct whether or not the IdP can accept
+data that has been compressed using [gzip](gzip) ('requests'). We can also determine
+whether or not the SP should expect to receive responses that have been compressed
+with [gzip](gzip) ('responses').
+
 In the security section, you can set the way that the SP will handle the messages
 and assertions. Contact the admin of the IdP and ask him what the IdP expects,
 and decide what validations will handle the SP and what requirements the SP will have
@@ -466,7 +476,7 @@ Once we know what kind of data could be configured, let's talk about the way
 settings are handled within the toolkit.
 
 The settings files described (`settings.php` and `advanced_settings.php`) are loaded
-by the toolkit if not other array with settings info is provided in the constructors of the toolkit. Let's see some examples. 
+by the toolkit if not other array with settings info is provided in the constructors of the toolkit. Let's see some examples.
 
 ```php
 // Initializes toolkit with settings.php & advanced_settings files.
@@ -507,7 +517,7 @@ define("TOOLKIT_PATH", '/var/www/php-saml/');
 require_once(TOOLKIT_PATH . '_toolkit_loader.php');
 ```
 
-After that line we will be able to use the classes (and their methods) of the 
+After that line we will be able to use the classes (and their methods) of the
 toolkit (because the external and the Saml2 libraries files are loaded).
 
 If you wrote the code of your SAML app for the version 1 of the PHP-SAML toolkit
@@ -519,7 +529,7 @@ toolkits but maintain the old classes, methods, and workflow of the old process
 to accomplish the same things.
 
 We strongly recommend migrating your old code and use the new API of the
-new toolkit due there are a lot of new features that you can't handle with the 
+new toolkit due there are a lot of new features that you can't handle with the
 old code.
 
 
@@ -542,7 +552,7 @@ The `AuthNRequest` will be sent signed or unsigned based on the security info
 of the `advanced_settings.php` (`'authnRequestsSigned'`).
 
 
-The IdP will then return the SAML Response to the user's client. The client is then forwarded to the Attribute Consumer Service of the SP with this information. If we do not set a 'url' param in the login method and we are using the default ACS provided by the toolkit (`endpoints/acs.php`), then the ACS endpoint will redirect the user to the file that launched the SSO request. 
+The IdP will then return the SAML Response to the user's client. The client is then forwarded to the Attribute Consumer Service of the SP with this information. If we do not set a 'url' param in the login method and we are using the default ACS provided by the toolkit (`endpoints/acs.php`), then the ACS endpoint will redirect the user to the file that launched the SSO request.
 
 We can set an `'returnTo'` url to change the workflow and redirect the user to the other PHP file.
 
@@ -573,7 +583,7 @@ exit();
 
 #### The SP Endpoints ####
 
-Related to the SP there are three important views: The metadata view, the ACS view and the SLS view. The toolkit 
+Related to the SP there are three important views: The metadata view, the ACS view and the SLS view. The toolkit
 provides examples of those views in the endpoints directory.
 
 ##### SP Metadata `endpoints/metadata.php` #####
@@ -729,7 +739,7 @@ Array
 )
 ```
 
-Each attribute name can be used as an index into `$attributes` to obtain the value. Every attribute value 
+Each attribute name can be used as an index into `$attributes` to obtain the value. Every attribute value
 is an array - a single-valued attribute is an array of a single element.
 
 
@@ -842,7 +852,7 @@ if (!OneLogin_Saml2_LogoutRequest::isValid($this->_settings, $request)) {
 }
 ```
 
-If you aren't using the default PHP session, or otherwise need a manual 
+If you aren't using the default PHP session, or otherwise need a manual
 way to destroy the session, you can pass a callback method to the
 `processSLO` method as the fourth parameter
 
@@ -881,7 +891,7 @@ $auth->logout();   // Method that sent the Logout Request.
 
 Also there are three optional parameters that can be set:
 
-* `$name_id` - That will be used to build the LogoutRequest. If `name_id` parameter is not set and the auth object processed a 
+* `$name_id` - That will be used to build the LogoutRequest. If `name_id` parameter is not set and the auth object processed a
 SAML Response with a `NameId`, then this `NameId` will be used.
 * `$session_index` - SessionIndex that identifies the session of the user.
 * `$strict` - True if we want to stay (returns the url string) False to redirect.
@@ -890,7 +900,7 @@ The Logout Request will be sent signed or unsigned based on the security
 info of the `advanced_settings.php` (`'logoutRequestSigned'`).
 
 The IdP will return the Logout Response through the user's client to the
-Single Logout Service of the SP. 
+Single Logout Service of the SP.
 If we do not set a `'url'` param in the logout method and are using the
 default SLS provided by the toolkit (`endpoints/sls.php`), then the SLS
 endpoint will redirect the user to the file that launched the SLO request.
@@ -917,7 +927,7 @@ exit();
 
 #### Example of a view that initiates the SSO request and handles the response (is the acs target) ####
 
-We can code a unique file that initiates the SSO process, handle the response, get the attributes, initiate 
+We can code a unique file that initiates the SSO process, handle the response, get the attributes, initiate
 the SLO and processes the logout response.
 
 Note: Review the `demo1` folder that contains that use case; in a later section we
@@ -938,31 +948,31 @@ $auth = new OneLogin_Saml2_Auth($settingsInfo);  // Initialize the SP SAML insta
 
 if (isset($_GET['sso'])) {    // SSO action.  Will send an AuthNRequest to the IdP
     $auth->login();
-} else if (isset($_GET['sso2'])) {              // Another SSO action 
+} else if (isset($_GET['sso2'])) {              // Another SSO action
     $returnTo = $spBaseUrl.'/demo1/attrs.php';  // but set a custom RelayState URL
     $auth->login($returnTo);
 } else if (isset($_GET['slo'])) {  // SLO action. Will sent a Logout Request to IdP
     $auth->logout();
 } else if (isset($_GET['acs'])) {  // Assertion Consumer Service
     $auth->processResponse();      // Process the Response of the IdP, get the
-                                   // attributes and put then at 
+                                   // attributes and put then at
                                    // $_SESSION['samlUserdata']
 
     $errors = $auth->getErrors();  // This method receives an array with the errors
-                                   // that could took place during the process 
+                                   // that could took place during the process
 
     if (!empty($errors)) {
         print_r('<p>'.implode(', ', $errors).'</p>');
     }
-                                          // This check if the response was 
+                                          // This check if the response was
     if (!$auth->isAuthenticated()) {      // sucessfully validated and the user
-        echo "<p>Not authenticated</p>";  // data retrieved or not 
+        echo "<p>Not authenticated</p>";  // data retrieved or not
         exit();
     }
 
     $_SESSION['samlUserdata'] = $auth->getAttributes(); // Retrieves user data
     if (isset($_POST['RelayState']) && OneLogin_Saml2_Utils::getSelfURL() != $_POST['RelayState']) {
-        $auth->redirectTo($_POST['RelayState']);  // Redirect if there is a 
+        $auth->redirectTo($_POST['RelayState']);  // Redirect if there is a
     }                                             // relayState set
 } else if (isset($_GET['sls'])) {   // Single Logout Service
     $auth->processSLO();            // Process the Logout Request & Logout Response
@@ -991,7 +1001,7 @@ if (isset($_SESSION['samlUserdata'])) {   // If there is user data we print it.
         echo "<p>You don't have any attribute</p>";
     }
 
-    echo '<p><a href="?slo" >Logout</a></p>'; // Print some links with possible 
+    echo '<p><a href="?slo" >Logout</a></p>'; // Print some links with possible
 } else {                                      // actions
     echo '<p><a href="?sso" >Login</a></p>';
     echo '<p><a href="?sso2" >Login and access to attrs.php page</a></p>';
@@ -1065,7 +1075,7 @@ Main class of OneLogin PHP Toolkit
  * `getAttribute` - Returns the requested SAML attribute
  * `getNameId` - Returns the nameID
  * `getSessionIndex` - Gets the SessionIndex from the AuthnStatement.
- * `getErrors` - Returns if there were any error 
+ * `getErrors` - Returns if there were any error
  * `getSSOurl` - Gets the SSO url.
  * `getSLOurl` - Gets the SLO url.
  * `getLastRequestID` - The ID of the last Request SAML message generated.
@@ -1163,7 +1173,7 @@ Configuration of the OneLogin PHP Toolkit
  * `setStrict` - Activates or deactivates the strict mode.
  * `isStrict` - Returns if the 'strict' mode is active.
  * `isDebugActive` - Returns if the debug is active.
-  
+
 ##### OneLogin_Saml2_Metadata - `Metadata.php` #####
 
 A class that contains functionality related to the metadata of the SP
@@ -1185,7 +1195,7 @@ Auxiliary class that contains several methods
    target url).
  * `isHTTPS` - Checks if https or http.
  * `getSelfHost` - Returns the current host.
- * `getSelfURLhost` - Returns the protocol + the current host + the port 
+ * `getSelfURLhost` - Returns the protocol + the current host + the port
    (if different than common ports).
  * `getSelfURLNoQuery` - Returns the URL of the current host + current view.
  * `getSelfURL` - Returns the URL of the current host + current view + query.
@@ -1193,7 +1203,7 @@ Auxiliary class that contains several methods
    for assertions).
  * `parseTime2SAML` - Converts a UNIX timestamp to SAML2 timestamp on the
    form `yyyy-mm-ddThh:mm:ss(\.s+)?Z`.
- * `parseSAML2Time` - Converts a SAML2 timestamp on the form 
+ * `parseSAML2Time` - Converts a SAML2 timestamp on the form
    `yyyy-mm-ddThh:mm:ss(\.s+)?Z` to a UNIX timestamp. The sub-second part is
    ignored.
  * `parseDuration` - Interprets a ISO8601 duration value relative to a given
@@ -1208,7 +1218,7 @@ Auxiliary class that contains several methods
  * `getStatus` - Gets Status from a Response.
  * `decryptElement` - Decrypts an encrypted element.
  * `castKey` - Converts a `XMLSecurityKey` to the correct algorithm.
- * `addSign` - Adds signature key and senders certificate to an element 
+ * `addSign` - Adds signature key and senders certificate to an element
    (Message or Assertion).
  * `validateSign` - Validates a signature (Message or Assertion).
 
@@ -1236,8 +1246,8 @@ The Onelogin's PHP Toolkit allows you to provide the settings info in two ways:
  * Use an array with the setting data.
 
 In this demo we provide the data in the second way, using a setting array named
-`$settingsInfo`. This array users the `settings_example.php` included as a template 
-to create the `settings.php` settings and store it in the `demo1/` folder. 
+`$settingsInfo`. This array users the `settings_example.php` included as a template
+to create the `settings.php` settings and store it in the `demo1/` folder.
 Configure the SP part and later review the metadata of the IdP and complete the IdP info.
 
 If you check the code of the index.php file you will see that the `settings.php`
@@ -1245,7 +1255,7 @@ file is loaded in order to get the `$settingsInfo` var to be used in order to in
 the `Setting` class.
 
 Notice that in this demo, the `setting.php` file that could be defined at the base
-folder of the toolkit is ignored and the libs are loaded using the 
+folder of the toolkit is ignored and the libs are loaded using the
 `_toolkit_loader.php` located at the base folder of the toolkit.
 
 
@@ -1261,40 +1271,40 @@ Once the SP is configured, the metadata of the SP is published at the
     to the same view or login and be redirected to the `attrs.php` view.
 
  2. When you click:
- 
+
     2.1 in the first link, we access to (`index.php?sso`) an `AuthNRequest`
     is sent to the IdP, we authenticate at the IdP and then a Response is sent
     through the user's client to the SP, specifically the Assertion Consumer Service view: `index.php?acs`.
     Notice that a `RelayState` parameter is set to the url that initiated the
     process, the `index.php` view.
 
-    2.2 in the second link we access to (`attrs.php`) have the same process 
+    2.2 in the second link we access to (`attrs.php`) have the same process
     described at 2.1 with the diference that as `RelayState` is set the `attrs.php`.
 
  3. The SAML Response is processed in the ACS (`index.php?acs`), if the Response
     is not valid, the process stops here and a message is shown. Otherwise we
     are redirected to the RelayState view. a) `index.php` or b) `attrs.php`.
 
- 4. We are logged in the app and the user attributes are showed. 
+ 4. We are logged in the app and the user attributes are showed.
     At this point, we can test the single log out functionality.
 
  5. The single log out functionality could be tested by two ways.
 
     5.1 SLO Initiated by SP. Click on the "logout" link at the SP, after that a
-    Logout Request is sent to the IdP, the session at the IdP is closed and 
+    Logout Request is sent to the IdP, the session at the IdP is closed and
     replies through the client to the SP with a Logout Response (sent to the
     Single Logout Service endpoint). The SLS endpoint (`index.php?sls`) of the SP
     process the Logout Response and if is valid, close the user session of the
     local app. Notice that the SLO Workflow starts and ends at the SP.
-   
+
     5.2 SLO Initiated by IdP. In this case, the action takes place on the IdP
-    side, the logout process is initiated at the idP, sends a Logout 
+    side, the logout process is initiated at the idP, sends a Logout
     Request to the SP (SLS endpoint, `index.php?sls`). The SLS endpoint of the SP
     process the Logout Request and if is valid, close the session of the user
     at the local app and send a Logout Response to the IdP (to the SLS endpoint
     of the IdP). The IdP receives the Logout Response, process it and close the
     session at of the IdP. Notice that the SLO Workflow starts and ends at the IdP.
-    
+
 Notice that all the SAML Requests and Responses are handled by a unique file,
 the `index.php` file and how `GET` paramters are used to know the action that
 must be done.
@@ -1310,7 +1320,7 @@ The Onelogin's PHP Toolkit allows you to provide the settings info in two ways:
    toolkit.
  * Use an array with the setting data.
 
-The first is the case of the demo2 app. The `setting.php` file and the 
+The first is the case of the demo2 app. The `setting.php` file and the
 `setting_extended.php` file should be defined at the base folder of the toolkit.
 Review the `setting_example.php` and the `advanced_settings_example.php` to
 learn how to build them.
@@ -1344,14 +1354,14 @@ demo1, only changes the targets.
     sent to the IdP automatically, (as `RelayState` is sent the origin url).
     We authenticate at the IdP and then a `Response` is sent to the SP, to the
     ACS endpoint, in this case `acs.php` of the endpoints folder.
- 
+
  2. The SAML Response is processed in the ACS, if the `Response` is not valid,
     the process stops here and a message is shown. Otherwise we are redirected
     to the `RelayState` view (`sso.php` or `index.php`). The `sso.php` detects if the
     user is logged and redirects to `index.php`, so we will be in the
     `index.php` at the end.
 
- 3. We are logged into the app and the user attributes (if any) are shown. 
+ 3. We are logged into the app and the user attributes (if any) are shown.
     At this point, we can test the single log out functionality.
 
  4. The single log out functionality could be tested by two ways.
@@ -1363,9 +1373,9 @@ demo1, only changes the targets.
     The SLS endpoint of the SP process the Logout Response and if is
     valid, close the user session of the local app. Notice that the SLO
     Workflow starts and ends at the SP.
-   
+
     5.2 SLO Initiated by IdP. In this case, the action takes place on the IdP
-    side, the logout process is initiated at the idP, sends a Logout 
+    side, the logout process is initiated at the idP, sends a Logout
     Request to the SP (SLS endpoint `sls.php` of the endpoint folder).
     The SLS endpoint of the SP process the Logout Request and if is valid,
     close the session of the user at the local app and sends a Logout Response

--- a/lib/Saml2/AuthnRequest.php
+++ b/lib/Saml2/AuthnRequest.php
@@ -137,12 +137,18 @@ AUTHNREQUEST;
 
     /**
      * Returns deflated, base64 encoded, unsigned AuthnRequest.
-     *
+     * 
+     * @param bool|null $deflate Whether or not we should 'gzdeflate' the request body before we return it.
      */
-    public function getRequest()
+    public function getRequest($deflate = null)
     {
         $subject = $this->_authnRequest;
-        if ($this->_settings->shouldCompressRequests()) {
+
+        if (is_null($deflate)) {
+            $deflate = $this->_settings->shouldCompressRequests();
+        }
+
+        if ($deflate) {
             $subject = gzdeflate($this->_authnRequest);
         }
 

--- a/lib/Saml2/AuthnRequest.php
+++ b/lib/Saml2/AuthnRequest.php
@@ -141,8 +141,12 @@ AUTHNREQUEST;
      */
     public function getRequest()
     {
-        $deflatedRequest = gzdeflate($this->_authnRequest);
-        $base64Request = base64_encode($deflatedRequest);
+        $subject = $this->_authnRequest;
+        if ($this->_settings->shouldCompressRequests()) {
+            $subject = gzdeflate($this->_authnRequest);
+        }
+
+        $base64Request = base64_encode($subject);
         return $base64Request;
     }
 

--- a/lib/Saml2/LogoutRequest.php
+++ b/lib/Saml2/LogoutRequest.php
@@ -110,12 +110,19 @@ LOGOUTREQUEST;
     /**
      * Returns the Logout Request defated, base64encoded, unsigned
      *
+     * @param bool|null $deflate Whether or not we should 'gzdeflate' the request body before we return it.
+     *
      * @return string Deflated base64 encoded Logout Request
      */
-    public function getRequest()
+    public function getRequest($deflate = null)
     {
         $subject = $this->_logoutRequest;
-        if ($this->_settings->shouldCompressRequests()) {
+
+        if (is_null($deflate)) {
+            $deflate = $this->_settings->shouldCompressRequests();
+        }
+
+        if ($deflate) {
             $subject = gzdeflate($this->_logoutRequest);
         }
 

--- a/lib/Saml2/LogoutRequest.php
+++ b/lib/Saml2/LogoutRequest.php
@@ -55,7 +55,7 @@ class OneLogin_Saml2_LogoutRequest
 
             $nameIdValue = OneLogin_Saml2_Utils::generateUniqueID();
             $issueInstant = OneLogin_Saml2_Utils::parseTime2SAML(time());
-            
+
             $cert = null;
             if (isset($security['nameIdEncrypted']) && $security['nameIdEncrypted']) {
                 $cert = $idpData['x509cert'];
@@ -114,8 +114,12 @@ LOGOUTREQUEST;
      */
     public function getRequest()
     {
-        $deflatedRequest = gzdeflate($this->_logoutRequest);
-        return base64_encode($deflatedRequest);
+        $subject = $this->_logoutRequest;
+        if ($this->_settings->shouldCompressRequests()) {
+            $subject = gzdeflate($this->_logoutRequest);
+        }
+
+        return base64_encode($subject);
     }
 
     /**
@@ -143,7 +147,7 @@ LOGOUTREQUEST;
      *
      * @param string|DOMDocument $request Logout Request Message
      * @param string|null        $key     The SP key
-     *     
+     *
      * @return array Name ID Data (Value, Format, NameQualifier, SPNameQualifier)
      *
      * @throws Exception
@@ -235,11 +239,11 @@ LOGOUTREQUEST;
     /**
      * Gets the SessionIndexes from the Logout Request.
      * Notice: Our Constructor only support 1 SessionIndex but this parser
-     *         extracts an array of all the  SessionIndex found on a  
+     *         extracts an array of all the  SessionIndex found on a
      *         Logout Request, that could be many.
      *
      * @param string|DOMDocument $request Logout Request Message
-     * 
+     *
      * @return array The SessionIndex value
      */
     public static function getSessionIndexes($request)
@@ -283,7 +287,7 @@ LOGOUTREQUEST;
                         throw new Exception("Invalid SAML Logout Request. Not match the saml-schema-protocol-2.0.xsd");
                     }
                 }
-                
+
                 $currentURL = OneLogin_Saml2_Utils::getSelfRoutedURLNoQuery();
 
                 // Check NotOnOrAfter
@@ -375,7 +379,7 @@ LOGOUTREQUEST;
 
     /* After execute a validation process, if fails this method returns the cause
      *
-     * @return string Cause 
+     * @return string Cause
      */
     public function getError()
     {

--- a/lib/Saml2/LogoutResponse.php
+++ b/lib/Saml2/LogoutResponse.php
@@ -244,13 +244,20 @@ LOGOUTRESPONSE;
 
     /**
      * Returns a Logout Response object.
-     *
+     * 
+     * @param bool|null $deflate Whether or not we should 'gzdeflate' the response body before we return it.
+     *                           
      * @return string Logout Response deflated and base64 encoded
      */
-    public function getResponse()
+    public function getResponse($deflate = null)
     {
         $subject = $this->_logoutResponse;
-        if ($this->_settings->shouldCompressResponses()) {
+
+        if (is_null($deflate)) {
+            $deflate = $this->_settings->shouldCompressResponses();
+        }
+
+        if ($deflate) {
             $subject = gzdeflate($this->_logoutResponse);
         }
         return base64_encode($subject);

--- a/lib/Saml2/LogoutResponse.php
+++ b/lib/Saml2/LogoutResponse.php
@@ -71,7 +71,7 @@ class OneLogin_Saml2_LogoutResponse
 
     /**
      * Gets the Status of the Logout Response.
-     * 
+     *
      * @return string The Status
      */
     public function getStatus()
@@ -213,7 +213,7 @@ class OneLogin_Saml2_LogoutResponse
     /**
      * Generates a Logout Response object.
      *
-     * @param string $inResponseTo InResponseTo value for the Logout Response. 
+     * @param string $inResponseTo InResponseTo value for the Logout Response.
      */
     public function build($inResponseTo)
     {
@@ -249,13 +249,16 @@ LOGOUTRESPONSE;
      */
     public function getResponse()
     {
-        $deflatedResponse = gzdeflate($this->_logoutResponse);
-        return base64_encode($deflatedResponse);
+        $subject = $this->_logoutResponse;
+        if ($this->_settings->shouldCompressResponses()) {
+            $subject = gzdeflate($this->_logoutResponse);
+        }
+        return base64_encode($subject);
     }
 
     /* After execute a validation process, if fails this method returns the cause.
      *
-     * @return string Cause 
+     * @return string Cause
      */
     public function getError()
     {

--- a/lib/Saml2/Settings.php
+++ b/lib/Saml2/Settings.php
@@ -45,6 +45,14 @@ class OneLogin_Saml2_Settings
     private $_idp = array();
 
     /**
+     * Compression settings that determine
+     * whether gzip compression should be used.
+     *
+     * @var array
+     */
+    private $_compress = array();
+
+    /**
      * Security Info related to the SP.
      *
      * @var array
@@ -232,6 +240,10 @@ class OneLogin_Saml2_Settings
                 $this->_debug = $settings['debug'];
             }
 
+            if (isset($settings['compress'])) {
+                $this->_compress = $settings['compress'];
+            }
+
             if (isset($settings['security'])) {
                 $this->_security = $settings['security'];
             }
@@ -295,6 +307,14 @@ class OneLogin_Saml2_Settings
         }
         if (isset($this->_sp['singleLogoutService']) && !isset($this->_sp['singleLogoutService']['binding'])) {
             $this->_sp['singleLogoutService']['binding'] = OneLogin_Saml2_Constants::BINDING_HTTP_REDIRECT;
+        }
+
+        if (!isset($this->_compress['requests'])) {
+            $this->_compress['requests'] = true;
+        }
+
+        if (!isset($this->_compress['responses'])) {
+            $this->_compress['responses'] = true;
         }
 
         // Related to nameID
@@ -393,8 +413,42 @@ class OneLogin_Saml2_Settings
             }
             $spErrors = $this->checkSPSettings($settings);
             $errors = array_merge($spErrors, $errors);
+
+            $compressErrors = $this->checkCompressionSettings($settings);
+            $errors = array_merge($compressErrors, $errors);
         }
 
+        return $errors;
+    }
+
+    /**
+     * Checks the compression settings info.
+     *
+     * @param array $settings Array with settings data
+     *
+     * @return array $errors  Errors found on the settings data
+     */
+    public function checkCompressionSettings($settings)
+    {
+        $errors = array();
+
+        if (isset($settings['compress'])) {
+            if (!is_array($settings['compress'])) {
+                $errors[] = "invalid_syntax";
+            } else if (
+                isset($settings['compress']['requests'])
+                && $settings['compress']['requests'] !== true
+                && $settings['compress']['requests'] !== false
+            ) {
+                $errors[] = "'compress'=>'requests' values must be true or false.";
+            } else if (
+                isset($settings['compress']['responses'])
+                && $settings['compress']['responses'] !== true
+                && $settings['compress']['responses'] !== false
+            ) {
+                $errors[] = "'compress'=>'responses' values must be true or false.";
+            }
+        }
         return $errors;
     }
 
@@ -663,6 +717,26 @@ class OneLogin_Saml2_Settings
     public function getOrganization()
     {
         return $this->_organization;
+    }
+
+    /**
+    * Should SAML requests be compressed?
+    *
+    * @return bool Yes/No as True/False
+    */
+    public function shouldCompressRequests()
+    {
+        return $this->_compress['requests'];
+    }
+
+    /**
+    * Should SAML responses be compressed?
+    *
+    * @return bool Yes/No as True/False
+    */
+    public function shouldCompressResponses()
+    {
+        return $this->_compress['responses'];
     }
 
     /**

--- a/tests/settings/settings1.php
+++ b/tests/settings/settings1.php
@@ -22,7 +22,10 @@
             ),
             'x509cert' => 'MIICgTCCAeoCCQCbOlrWDdX7FTANBgkqhkiG9w0BAQUFADCBhDELMAkGA1UEBhMCTk8xGDAWBgNVBAgTD0FuZHJlYXMgU29sYmVyZzEMMAoGA1UEBxMDRm9vMRAwDgYDVQQKEwdVTklORVRUMRgwFgYDVQQDEw9mZWlkZS5lcmxhbmcubm8xITAfBgkqhkiG9w0BCQEWEmFuZHJlYXNAdW5pbmV0dC5ubzAeFw0wNzA2MTUxMjAxMzVaFw0wNzA4MTQxMjAxMzVaMIGEMQswCQYDVQQGEwJOTzEYMBYGA1UECBMPQW5kcmVhcyBTb2xiZXJnMQwwCgYDVQQHEwNGb28xEDAOBgNVBAoTB1VOSU5FVFQxGDAWBgNVBAMTD2ZlaWRlLmVybGFuZy5ubzEhMB8GCSqGSIb3DQEJARYSYW5kcmVhc0B1bmluZXR0Lm5vMIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQDivbhR7P516x/S3BqKxupQe0LONoliupiBOesCO3SHbDrl3+q9IbfnfmE04rNuMcPsIxB161TdDpIesLCn7c8aPHISKOtPlAeTZSnb8QAu7aRjZq3+PbrP5uW3TcfCGPtKTytHOge/OlJbo078dVhXQ14d1EDwXJW1rRXuUt4C8QIDAQABMA0GCSqGSIb3DQEBBQUAA4GBACDVfp86HObqY+e8BUoWQ9+VMQx1ASDohBjwOsg2WykUqRXF+dLfcUH9dWR63CtZIKFDbStNomPnQz7nbK+onygwBspVEbnHuUihZq3ZUdmumQqCw4Uvs/1Uvq3orOo/WJVhTyvLgFVK2QarQ4/67OZfHd7R+POBXhophSMv1ZOo',
         ),
-
+        'compress' => array(
+            'requests' => true,
+            'responses' => true
+        ),
         'security' => array (
             'authnRequestsSigned' => false,
             'wantAssertionsSigned' => false,

--- a/tests/settings/settings2.php
+++ b/tests/settings/settings2.php
@@ -25,7 +25,10 @@ $settingsInfo = array (
         ),
         'x509cert' => 'MIICgTCCAeoCCQCbOlrWDdX7FTANBgkqhkiG9w0BAQUFADCBhDELMAkGA1UEBhMCTk8xGDAWBgNVBAgTD0FuZHJlYXMgU29sYmVyZzEMMAoGA1UEBxMDRm9vMRAwDgYDVQQKEwdVTklORVRUMRgwFgYDVQQDEw9mZWlkZS5lcmxhbmcubm8xITAfBgkqhkiG9w0BCQEWEmFuZHJlYXNAdW5pbmV0dC5ubzAeFw0wNzA2MTUxMjAxMzVaFw0wNzA4MTQxMjAxMzVaMIGEMQswCQYDVQQGEwJOTzEYMBYGA1UECBMPQW5kcmVhcyBTb2xiZXJnMQwwCgYDVQQHEwNGb28xEDAOBgNVBAoTB1VOSU5FVFQxGDAWBgNVBAMTD2ZlaWRlLmVybGFuZy5ubzEhMB8GCSqGSIb3DQEJARYSYW5kcmVhc0B1bmluZXR0Lm5vMIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQDivbhR7P516x/S3BqKxupQe0LONoliupiBOesCO3SHbDrl3+q9IbfnfmE04rNuMcPsIxB161TdDpIesLCn7c8aPHISKOtPlAeTZSnb8QAu7aRjZq3+PbrP5uW3TcfCGPtKTytHOge/OlJbo078dVhXQ14d1EDwXJW1rRXuUt4C8QIDAQABMA0GCSqGSIb3DQEBBQUAA4GBACDVfp86HObqY+e8BUoWQ9+VMQx1ASDohBjwOsg2WykUqRXF+dLfcUH9dWR63CtZIKFDbStNomPnQz7nbK+onygwBspVEbnHuUihZq3ZUdmumQqCw4Uvs/1Uvq3orOo/WJVhTyvLgFVK2QarQ4/67OZfHd7R+POBXhophSMv1ZOo',
     ),
-
+    'compress' => array(
+        'requests' => false,
+        'responses' => false
+    ),
     'security' => array (
         'authnRequestsSigned' => false,
         'wantAssertionsSigned' => false,

--- a/tests/src/OneLogin/Saml2/AuthnRequestTest.php
+++ b/tests/src/OneLogin/Saml2/AuthnRequestTest.php
@@ -226,4 +226,43 @@ class OneLogin_Saml2_AuthnRequestTest extends PHPUnit_Framework_TestCase
         $this->assertRegExp('#Format="urn:oasis:names:tc:SAML:2.0:nameid-format:encrypted"#', $message);
         $this->assertRegExp('#ProviderName="SP prueba"#', $message);
     }
+
+    /**
+    * Tests that a 'true' value for compress => requests gets honored when we
+    * try to obtain the request payload from getRequest()
+    *
+    * @covers OneLogin_Saml2_AuthnRequest::getRequest()
+    */
+    public function testWeCanChooseToCompressARequest()
+    {
+        //Test that we can compress.
+        $settingsDir = TEST_ROOT .'/settings/';
+        include $settingsDir.'settings1.php';
+
+        $settings = new OneLogin_Saml2_Settings($settingsInfo);
+        $authnRequest = new OneLogin_Saml2_AuthnRequest($settings);
+        $payload = $authnRequest->getRequest();
+        $decoded = base64_decode($payload);
+        $decompressed = gzinflate($decoded);
+        $this->assertRegExp('#^<samlp:AuthnRequest#', $decompressed);
+    }
+
+    /**
+    * Tests that a 'false' value for compress => requests gets honored when we
+    * try to obtain the request payload from getRequest()
+    *
+    * @covers OneLogin_Saml2_AuthnRequest::getRequest()
+    */
+    public function testWeCanChooseNotToCompressARequest()
+    {
+        //Test that we can choose not to compress the request payload.
+        $settingsDir = TEST_ROOT .'/settings/';
+        include $settingsDir.'settings2.php';
+
+        $settings = new OneLogin_Saml2_Settings($settingsInfo);
+        $authnRequest = new OneLogin_Saml2_AuthnRequest($settings);
+        $payload = $authnRequest->getRequest();
+        $decoded = base64_decode($payload);
+        $this->assertRegExp('#^<samlp:AuthnRequest#', $decoded);
+    }
 }

--- a/tests/src/OneLogin/Saml2/AuthnRequestTest.php
+++ b/tests/src/OneLogin/Saml2/AuthnRequestTest.php
@@ -265,4 +265,37 @@ class OneLogin_Saml2_AuthnRequestTest extends PHPUnit_Framework_TestCase
         $decoded = base64_decode($payload);
         $this->assertRegExp('#^<samlp:AuthnRequest#', $decoded);
     }
+
+    /**
+     * Tests that we can pass a boolean value to the getRequest()
+     * method to choose whether it should 'gzdeflate' the body
+     * of the request.
+     *
+     * @covers OneLogin_Saml2_AuthnRequest::getRequest()
+     */
+    public function testWeCanChooseToDeflateARequestBody()
+    {
+        //Test that we can choose not to compress the request payload.
+        $settingsDir = TEST_ROOT .'/settings/';
+        include $settingsDir.'settings1.php';
+
+        //Compression is currently turned on in settings.
+        $settings = new OneLogin_Saml2_Settings($settingsInfo);
+        $authnRequest = new OneLogin_Saml2_AuthnRequest($settings);
+        $payload = $authnRequest->getRequest(false);
+        $decoded = base64_decode($payload);
+        $this->assertRegExp('#^<samlp:AuthnRequest#', $decoded);
+
+        //Test that we can choose not to compress the request payload.
+        $settingsDir = TEST_ROOT .'/settings/';
+        include $settingsDir.'settings2.php';
+
+        //Compression is currently turned off in settings.
+        $settings = new OneLogin_Saml2_Settings($settingsInfo);
+        $authnRequest = new OneLogin_Saml2_AuthnRequest($settings);
+        $payload = $authnRequest->getRequest(true);
+        $decoded = base64_decode($payload);
+        $decompressed = gzinflate($decoded);
+        $this->assertRegExp('#^<samlp:AuthnRequest#', $decompressed);
+    }
 }

--- a/tests/src/OneLogin/Saml2/LogoutRequestTest.php
+++ b/tests/src/OneLogin/Saml2/LogoutRequestTest.php
@@ -483,6 +483,39 @@ class OneLogin_Saml2_LogoutRequestTest extends PHPUnit_Framework_TestCase
     }
 
     /**
+     * Tests that we can pass a boolean value to the getRequest()
+     * method to choose whether it should 'gzdeflate' the body
+     * of the request.
+     *
+     * @covers OneLogin_Saml2_LogoutRequest::getRequest()
+     */
+    public function testWeCanChooseToDeflateARequestBody()
+    {
+        //Test that we can choose not to compress the request payload.
+        $settingsDir = TEST_ROOT .'/settings/';
+        include $settingsDir.'settings1.php';
+
+        //Compression is currently turned on in settings.
+        $settings = new OneLogin_Saml2_Settings($settingsInfo);
+        $logoutRequest = new OneLogin_Saml2_LogoutRequest($settings);
+        $payload = $logoutRequest->getRequest(false);
+        $decoded = base64_decode($payload);
+        $this->assertRegExp('#^<samlp:LogoutRequest#', $decoded);
+
+        //Test that we can choose not to compress the request payload.
+        $settingsDir = TEST_ROOT .'/settings/';
+        include $settingsDir.'settings2.php';
+
+        //Compression is currently turned off in settings.
+        $settings = new OneLogin_Saml2_Settings($settingsInfo);
+        $logoutRequest = new OneLogin_Saml2_LogoutRequest($settings);
+        $payload = $logoutRequest->getRequest(true);
+        $decoded = base64_decode($payload);
+        $decompressed = gzinflate($decoded);
+        $this->assertRegExp('#^<samlp:LogoutRequest#', $decompressed);
+    }
+
+    /**
     * Tests the isValid method of the OneLogin_Saml2_LogoutRequest
     *
     * @covers OneLogin_Saml2_LogoutRequest::isValid

--- a/tests/src/OneLogin/Saml2/LogoutRequestTest.php
+++ b/tests/src/OneLogin/Saml2/LogoutRequestTest.php
@@ -20,7 +20,7 @@ class OneLogin_Saml2_LogoutRequestTest extends PHPUnit_Framework_TestCase
     }
 
     /**
-    * Tests the OneLogin_Saml2_LogoutRequest Constructor. 
+    * Tests the OneLogin_Saml2_LogoutRequest Constructor.
     *
     * @covers OneLogin_Saml2_LogoutRequest
     */
@@ -47,7 +47,7 @@ class OneLogin_Saml2_LogoutRequestTest extends PHPUnit_Framework_TestCase
     }
 
     /**
-    * Tests the OneLogin_Saml2_LogoutRequest Constructor. 
+    * Tests the OneLogin_Saml2_LogoutRequest Constructor.
     *
     * @covers OneLogin_Saml2_LogoutRequest
     */
@@ -74,7 +74,7 @@ class OneLogin_Saml2_LogoutRequestTest extends PHPUnit_Framework_TestCase
     }
 
     /**
-    * Tests the OneLogin_Saml2_LogoutRequest Constructor. 
+    * Tests the OneLogin_Saml2_LogoutRequest Constructor.
     *
     * @covers OneLogin_Saml2_LogoutRequest
     */
@@ -105,7 +105,7 @@ class OneLogin_Saml2_LogoutRequestTest extends PHPUnit_Framework_TestCase
     }
 
     /**
-    * Tests the OneLogin_Saml2_LogoutRequest Constructor. 
+    * Tests the OneLogin_Saml2_LogoutRequest Constructor.
     * The creation of a deflated SAML Logout Request
     *
     * @covers OneLogin_Saml2_LogoutRequest
@@ -188,7 +188,7 @@ class OneLogin_Saml2_LogoutRequestTest extends PHPUnit_Framework_TestCase
         } catch (Exception $e) {
             $this->assertContains('Key is required in order to decrypt the NameID', $e->getMessage());
         }
-        
+
         $key = $this->_settings->getSPkey();
         $nameIdData4 = OneLogin_Saml2_LogoutRequest::getNameIdData($request2, $key);
 
@@ -443,6 +443,46 @@ class OneLogin_Saml2_LogoutRequestTest extends PHPUnit_Framework_TestCase
     }
 
     /**
+    * Tests that a 'true' value for compress => requests gets honored when we
+    * try to obtain the request payload from getRequest()
+    *
+    * @covers OneLogin_Saml2_LogoutRequest::getRequest()
+    */
+    public function testWeCanChooseToCompressARequest()
+    {
+        //Test that we can compress.
+        $settingsDir = TEST_ROOT .'/settings/';
+        include $settingsDir.'settings1.php';
+
+        $settings = new OneLogin_Saml2_Settings($settingsInfo);
+        $logoutRequest = new OneLogin_Saml2_LogoutRequest($settings);
+        $payload = $logoutRequest->getRequest();
+        $decoded = base64_decode($payload);
+        $decompressed = gzinflate($decoded);
+        $this->assertRegExp('#^<samlp:LogoutRequest#', $decompressed);
+
+    }
+
+    /**
+    * Tests that a 'false' value for compress => requests gets honored when we
+    * try to obtain the request payload from getRequest()
+    *
+    * @covers OneLogin_Saml2_LogoutRequest::getRequest()
+    */
+    public function testWeCanChooseNotToCompressARequest()
+    {
+        //Test that we can choose not to compress the request payload.
+        $settingsDir = TEST_ROOT .'/settings/';
+        include $settingsDir.'settings2.php';
+
+        $settings = new OneLogin_Saml2_Settings($settingsInfo);
+        $logoutRequest = new OneLogin_Saml2_LogoutRequest($settings);
+        $payload = $logoutRequest->getRequest();
+        $decoded = base64_decode($payload);
+        $this->assertRegExp('#^<samlp:LogoutRequest#', $decoded);
+    }
+
+    /**
     * Tests the isValid method of the OneLogin_Saml2_LogoutRequest
     *
     * @covers OneLogin_Saml2_LogoutRequest::isValid
@@ -493,7 +533,7 @@ class OneLogin_Saml2_LogoutRequestTest extends PHPUnit_Framework_TestCase
         $this->assertContains('Signature validation failed. Logout Request rejected', $logoutRequest3->getError());
 
         $this->_settings->setStrict(true);
-        
+
         $request2 = str_replace('https://pitbulk.no-ip.org/newonelogin/demo1/index.php?sls', $currentURL, $request);
         $request2 = str_replace('https://pitbulk.no-ip.org/simplesaml/saml2/idp/metadata.php', 'http://idp.example.com/', $request2);
 
@@ -522,7 +562,7 @@ class OneLogin_Saml2_LogoutRequestTest extends PHPUnit_Framework_TestCase
         include $settingsDir.'settings1.php';
         $settingsInfo['strict'] = true;
         $settingsInfo['security']['wantMessagesSigned'] = true;
-        
+
         $settings = new OneLogin_Saml2_Settings($settingsInfo);
 
         $_GET['SigAlg'] = $oldSigAlg;
@@ -534,7 +574,7 @@ class OneLogin_Saml2_LogoutRequestTest extends PHPUnit_Framework_TestCase
         $this->assertEquals('The Message of the Logout Request is not signed and the SP require it', $logoutRequest6->getError());
 
         $_GET['Signature'] = $oldSignature;
-       
+
         $settingsInfo['idp']['certFingerprint'] = 'afe71c28ef740bc87425be13a2263d37971da1f9';
         unset($settingsInfo['idp']['x509cert']);
         $settings2 = new OneLogin_Saml2_Settings($settingsInfo);

--- a/tests/src/OneLogin/Saml2/LogoutResponseTest.php
+++ b/tests/src/OneLogin/Saml2/LogoutResponseTest.php
@@ -20,7 +20,7 @@ class OneLogin_Saml2_LogoutResponseTest extends PHPUnit_Framework_TestCase
     }
 
     /**
-    * Tests the OneLogin_Saml2_LogoutResponse Constructor. 
+    * Tests the OneLogin_Saml2_LogoutResponse Constructor.
     *
     * @covers OneLogin_Saml2_LogoutResponse
     */
@@ -32,7 +32,7 @@ class OneLogin_Saml2_LogoutResponseTest extends PHPUnit_Framework_TestCase
     }
 
     /**
-    * Tests the OneLogin_Saml2_LogoutResponse Constructor. 
+    * Tests the OneLogin_Saml2_LogoutResponse Constructor.
     * The creation of a deflated SAML Logout Response
     *
     * @covers OneLogin_Saml2_LogoutResponse
@@ -189,7 +189,7 @@ class OneLogin_Saml2_LogoutResponseTest extends PHPUnit_Framework_TestCase
         $settings->setStrict(false);
 
         $message = file_get_contents(TEST_ROOT . '/data/logout_responses/invalids/invalid_xml.xml.base64');
-        
+
         $response = new OneLogin_Saml2_LogoutResponse($settings, $message);
 
         $this->assertTrue($response->isValid());
@@ -301,7 +301,7 @@ class OneLogin_Saml2_LogoutResponseTest extends PHPUnit_Framework_TestCase
         include $settingsDir.'settings1.php';
         $settingsInfo['strict'] = true;
         $settingsInfo['security']['wantMessagesSigned'] = true;
-        
+
         $settings = new OneLogin_Saml2_Settings($settingsInfo);
 
         $_GET['SigAlg'] = $oldSigAlg;
@@ -313,7 +313,7 @@ class OneLogin_Saml2_LogoutResponseTest extends PHPUnit_Framework_TestCase
         $this->assertEquals('The Message of the Logout Response is not signed and the SP requires it', $response9->getError());
 
         $_GET['Signature'] = $oldSignature;
-       
+
         $settingsInfo['idp']['certFingerprint'] = 'afe71c28ef740bc87425be13a2263d37971da1f9';
         unset($settingsInfo['idp']['x509cert']);
         $settings2 = new OneLogin_Saml2_Settings($settingsInfo);
@@ -347,5 +347,53 @@ class OneLogin_Saml2_LogoutResponseTest extends PHPUnit_Framework_TestCase
 
         $response3 = new OneLogin_Saml2_LogoutResponse($this->_settings, $message3);
         $this->assertTrue($response3->isValid());
+    }
+
+    /**
+    * Tests that a 'true' value for compress => responses gets honored when we
+    * try to obtain the request payload from getResponse()
+    *
+    * @covers OneLogin_Saml2_LogoutResponse::getResponse()
+    */
+    public function testWeCanChooseToCompressAResponse()
+    {
+        //Test that we can compress.
+        $settingsDir = TEST_ROOT .'/settings/';
+        include $settingsDir.'settings1.php';
+
+        $message = file_get_contents(
+            TEST_ROOT . '/data/logout_responses/logout_response_deflated.xml.base64'
+        );
+
+        $settings = new OneLogin_Saml2_Settings($settingsInfo);
+        $logoutResponse = new OneLogin_Saml2_LogoutResponse($settings, $message);
+        $payload = $logoutResponse->getResponse();
+        $decoded = base64_decode($payload);
+        $decompressed = gzinflate($decoded);
+        $this->assertRegExp('#^<samlp:LogoutResponse#', $decompressed);
+
+    }
+
+    /**
+    * Tests that a 'false' value for compress => responses gets honored when we
+    * try to obtain the request payload from getResponse()
+    *
+    * @covers OneLogin_Saml2_LogoutResponse::getResponse()
+    */
+    public function testWeCanChooseNotToCompressAResponse()
+    {
+        //Test that we can choose not to compress the request payload.
+        $settingsDir = TEST_ROOT .'/settings/';
+        include $settingsDir.'settings2.php';
+
+        $message = file_get_contents(
+            TEST_ROOT . '/data/logout_responses/logout_response_deflated.xml.base64'
+        );
+
+        $settings = new OneLogin_Saml2_Settings($settingsInfo);
+        $logoutResponse = new OneLogin_Saml2_LogoutResponse($settings, $message);
+        $payload = $logoutResponse->getResponse();
+        $decoded = base64_decode($payload);
+        $this->assertRegExp('#^<samlp:LogoutResponse#', $decoded);
     }
 }

--- a/tests/src/OneLogin/Saml2/LogoutResponseTest.php
+++ b/tests/src/OneLogin/Saml2/LogoutResponseTest.php
@@ -396,4 +396,35 @@ class OneLogin_Saml2_LogoutResponseTest extends PHPUnit_Framework_TestCase
         $decoded = base64_decode($payload);
         $this->assertRegExp('#^<samlp:LogoutResponse#', $decoded);
     }
+
+    public function testWeCanChooseToDeflateAResponseBody()
+    {
+
+        $message = file_get_contents(
+            TEST_ROOT . '/data/logout_responses/logout_response_deflated.xml.base64'
+        );
+
+        //Test that we can choose not to compress the request payload.
+        $settingsDir = TEST_ROOT .'/settings/';
+        include $settingsDir.'settings1.php';
+        
+        //Compression is currently turned on in settings.
+        $settings = new OneLogin_Saml2_Settings($settingsInfo);
+        $logoutResponse = new OneLogin_Saml2_LogoutResponse($settings, $message);
+        $payload = $logoutResponse->getResponse(false);
+        $decoded = base64_decode($payload);
+        $this->assertRegExp('#^<samlp:LogoutResponse#', $decoded);
+
+        //Test that we can choose not to compress the request payload.
+        $settingsDir = TEST_ROOT .'/settings/';
+        include $settingsDir.'settings2.php';
+        
+        //Compression is currently turned on in settings.
+        $settings = new OneLogin_Saml2_Settings($settingsInfo);
+        $logoutResponse = new OneLogin_Saml2_LogoutResponse($settings, $message);
+        $payload = $logoutResponse->getResponse(true);
+        $decoded = base64_decode($payload);
+        $decompressed = gzinflate($decoded);
+        $this->assertRegExp('#^<samlp:LogoutResponse#', $decompressed);
+    }
 }

--- a/tests/src/OneLogin/Saml2/SettingsTest.php
+++ b/tests/src/OneLogin/Saml2/SettingsTest.php
@@ -126,6 +126,131 @@ class OneLogin_Saml2_SettingsTest extends PHPUnit_Framework_TestCase
     }
 
     /**
+    * Tests shouldCompressRequests method of OneLogin_Saml2_Settings.
+    *
+    * @covers OneLogin_Saml2_settings::shouldCompressRequests
+    */
+    public function testShouldCompressRequests()
+    {
+        //The default value should be true.
+        $settings = new OneLogin_Saml2_Settings();
+        $this->assertTrue($settings->shouldCompressRequests());
+
+        $settingsDir = TEST_ROOT .'/settings/';
+        include $settingsDir.'settings1.php';
+
+        //settings1.php contains a true value for compress => requests.
+        $settings = new OneLogin_Saml2_Settings($settingsInfo);
+        $this->assertTrue($settings->shouldCompressRequests());
+
+        $settingsDir = TEST_ROOT .'/settings/';
+        include $settingsDir.'settings2.php';
+
+        //settings2 contains a false value for compress => requests.
+        $settings = new OneLogin_Saml2_Settings($settingsInfo);
+        $this->assertFalse($settings->shouldCompressRequests());
+    }
+
+    /**
+    * Tests shouldCompressResponses method of OneLogin_Saml2_Settings.
+    *
+    * @covers OneLogin_Saml2_settings::shouldCompressResponses
+    */
+    public function testShouldCompressResponses()
+    {
+        //The default value should be true.
+        $settings = new OneLogin_Saml2_Settings();
+        $this->assertTrue($settings->shouldCompressResponses());
+
+        $settingsDir = TEST_ROOT .'/settings/';
+        include $settingsDir.'settings1.php';
+
+        //settings1.php contains a true value for compress => responses.
+        $settings = new OneLogin_Saml2_Settings($settingsInfo);
+        $this->assertTrue($settings->shouldCompressResponses());
+
+        $settingsDir = TEST_ROOT .'/settings/';
+        include $settingsDir.'settings2.php';
+
+        //settings2 contains a false value for compress => responses.
+        $settings = new OneLogin_Saml2_Settings($settingsInfo);
+        $this->assertFalse($settings->shouldCompressResponses());
+    }
+
+    /**
+     * Tests the checkCompressionSettings method of OneLogin_Saml2_settings.
+     * @dataProvider invalidCompressSettingsProvider
+     * @covers OneLogin_Saml2_settings::checkCompressionSettings
+     */
+    public function testNonArrayCompressionSettingsCauseSyntaxError($invalidValue)
+    {
+
+        $settingsDir = TEST_ROOT .'/settings/';
+        include $settingsDir.'settings1.php';
+
+        $settingsInfo['compress'] = $invalidValue;
+
+        try {
+           $settings = new OneLogin_Saml2_Settings($settingsInfo);
+        } catch(OneLogin_Saml2_error $error) {
+           $expectedMessage = "Invalid array settings: invalid_syntax";
+           $this->assertEquals($expectedMessage, $error->getMessage());
+           return;
+        }
+
+        $this->fail("An OneLogin_Saml2_error should have been caught.");
+    }
+
+    /**
+     * Tests the checkCompressionSettings method of OneLogin_Saml2_settings.
+     * @dataProvider invalidCompressSettingsProvider
+     * @covers OneLogin_Saml2_settings::checkCompressionSettings
+     */
+    public function testThatOnlyBooleansCanBeUsedForCompressionSettings($invalidValue)
+    {
+
+        $requestsIsInvalid = false;
+        $responsesIsInvalid = false;
+
+        try {
+            $settingsDir = TEST_ROOT .'/settings/';
+            include $settingsDir.'settings1.php';
+
+            $settingsInfo['compress']['requests'] = $invalidValue;
+            $settings = new OneLogin_Saml2_Settings($settingsInfo);
+        } catch(OneLogin_Saml2_error $error) {
+             $expectedMessage = "Invalid array settings: 'compress'=>'requests' values must be true or false.";
+             $this->assertEquals($expectedMessage, $error->getMessage());
+             $requestsIsInvalid = true;
+        }
+
+        try {
+            $settingsDir = TEST_ROOT .'/settings/';
+            include $settingsDir.'settings1.php';
+
+            $settingsInfo['compress']['responses'] = $invalidValue;
+            $settings = new OneLogin_Saml2_Settings($settingsInfo);
+        } catch(OneLogin_Saml2_error $error) {
+             $expectedMessage = "Invalid array settings: 'compress'=>'responses' values must be true or false.";
+             $this->assertEquals($expectedMessage, $error->getMessage());
+             $responsesIsInvalid = true;
+        }
+
+        $this->assertTrue($requestsIsInvalid);
+        $this->assertTrue($responsesIsInvalid);
+    }
+
+    public function invalidCompressSettingsProvider()
+    {
+        return array(
+            array(1),
+            array(0.1),
+            array(new \stdClass),
+            array("A random string.")
+        );
+    }
+
+    /**
     * Tests the checkSPCerts method of the OneLogin_Saml2_Settings
     *
     * @covers OneLogin_Saml2_Settings::checkSPCerts


### PR DESCRIPTION
@pitbulk This should fit more with your comments in #141.

Only change I made was to add a new 'compression' settings option instead of adding the options under 'security'. I also added a Onelogin_Saml2_Settings::checkCompressionSettings() method and tests for it.

Cheers,
Will