### PR TITLE
Checking if messages should be signed before validating signed content.

### DIFF
--- a/lib/Saml2/Response.php
+++ b/lib/Saml2/Response.php
@@ -256,7 +256,13 @@ class OneLogin_Saml2_Response
                 }
             }
 
-            if (!empty($signedElements)) {
+            $security = $this->_settings->getSecurityData();
+
+            $wantMessagesSigned = $this->_settings->isStrict() || $security['wantMessagesSigned'];
+
+            if ($wantMessagesSigned && empty($signedElements)) {
+                throw new Exception('No Signature found. SAML Response rejected');
+            } else if ($wantMessagesSigned) {
                 $cert = $idpData['x509cert'];
                 $fingerprint = $idpData['certFingerprint'];
                 $fingerprintalg = $idpData['certFingerprintAlgorithm'];
@@ -280,8 +286,6 @@ class OneLogin_Saml2_Response
                 if (!OneLogin_Saml2_Utils::validateSign($documentToValidate, $cert, $fingerprint, $fingerprintalg)) {
                     throw new Exception('Signature validation failed. SAML Response rejected');
                 }
-            } else {
-                throw new Exception('No Signature found. SAML Response rejected');
             }
             return true;
         } catch (Exception $e) {

--- a/tests/src/OneLogin/Saml2/ResponseTest.php
+++ b/tests/src/OneLogin/Saml2/ResponseTest.php
@@ -974,7 +974,7 @@ class OneLogin_Saml2_ResponseTest extends PHPUnit_Framework_TestCase
         $settingsInfo['security']['wantAssertionsSigned'] = false;
         $settingsInfo['strict'] = false;
 
-        $settingsInfo['security']['wantMessagesSigned'] = false;
+        $settingsInfo['security']['wantMessagesSigned'] = true;
         $settings5 = new OneLogin_Saml2_Settings($settingsInfo);
         $response5 = new OneLogin_Saml2_Response($settings5, $message);
         $response5->isValid();


### PR DESCRIPTION
'No Signature found. SAML Response rejected' was being thrown when 'wantMessagesSigned' was set to false.