### PR TITLE
Add a replace section so the original xmlseclibs will never installed

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,6 +31,9 @@
         "pdepend/pdepend" : "1.1.0",
         "squizlabs/php_codesniffer": "*"
     },
+    "replace": {
+        "robrichards/xmlseclibs": "*"
+    },
     "suggest": {
         "lib-openssl": "Install openssl lib in order to handle with x509 certs (require to support sign and encryption)",
         "ext-mcrypt": "Install mcrypt and php5-mcrypt libs in order to support encryption",


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Fixed tickets | partially #81 |
| Related issues/PRs | robrichards/xmlseclibs#104 |
| License | MIT |
#### What's in this PR?

This adds a replace section to the `composer.json` which says this library replaces the xmlseclibs. Thus the the xmlseclibs will no longer get installed via composer as you need your modified ones.

After xmlseclibs finally has a release (note robrichards/xmlseclibs#104) this must be reverted. Maybe this will be only a shortly living bugfix release, but we would happy if we can get a release of php-saml after merging this :grinning: 
#### Why?

This gets finally rid of the ambigious class resolution warnings:

```
Generating autoload files
Warning: Ambiguous class resolution, "XMLSecEnc" was found in both "/vagrant/vendor/onelogin/php-saml/extlib/xmlseclibs/xmlseclibs.php" and "/vagrant/vendor/rob
richards/xmlseclibs/src/XMLSecEnc.php", the first will be used.
Warning: Ambiguous class resolution, "XMLSecurityDSig" was found in both "/vagrant/vendor/onelogin/php-saml/extlib/xmlseclibs/xmlseclibs.php" and "/vagrant/vend
or/robrichards/xmlseclibs/src/XMLSecurityDSig.php", the first will be used.
Warning: Ambiguous class resolution, "XMLSecurityKey" was found in both "/vagrant/vendor/onelogin/php-saml/extlib/xmlseclibs/xmlseclibs.php" and "/vagrant/vendo
r/robrichards/xmlseclibs/src/XMLSecurityKey.php", the first will be used.
```

Having this in mind, it is rather coincidence that your supplied and modified version of xmlseclib gets chosen first and not the ones installed via composer. If it would be otherwise, php-saml would crash, as said in #81 you've backported stuff from master of xmlseclibs
