### PR TITLE
Add saml attributes in metadata

### DIFF
--- a/tests/settings/settings3.php
+++ b/tests/settings/settings3.php
@@ -1,0 +1,71 @@
+<?php
+    $settingsInfo = array (
+        'strict' => false,
+        'debug' => false,
+        'sp' => array (
+            'entityId' => 'http://stuff.com/endpoints/metadata.php',
+            'assertionConsumerService' => array (
+                'url' => 'http://stuff.com/endpoints/endpoints/acs.php',
+            ),
+            'singleLogoutService' => array (
+                'url' => 'http://stuff.com/endpoints/endpoints/sls.php',
+            ),
+            'NameIDFormat' => 'urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified',
+            'attributeConsumingService' => array (
+                'serviceName' => 'Service Name',
+                'serviceDescription' => 'Service Description',
+                'requestedAttributes' => array (
+                    array (
+                        'nameFormat' => \OneLogin_Saml2_Constants::ATTRNAME_FORMAT_URI,
+                        'isRequired' => true,
+                        'name' => 'Email',
+                        'friendlyName' => 'Email'
+                    ),
+                    array (
+                        'nameFormat' => \OneLogin_Saml2_Constants::ATTRNAME_FORMAT_URI,
+                        'isRequired' => true,
+                        'name' => 'FirstName'
+                    ),
+                    array (
+                        'nameFormat' => \OneLogin_Saml2_Constants::ATTRNAME_FORMAT_URI,
+                        'isRequired' => true,
+                        'name' => 'LastName',
+                    ),
+                )
+            )
+        ),
+        'idp' => array (
+            'entityId' => 'http://idp.example.com/',
+            'singleSignOnService' => array (
+                'url' => 'http://idp.example.com/SSOService.php',
+            ),
+            'singleLogoutService' => array (
+                'url' => 'http://idp.example.com/SingleLogoutService.php',
+            ),
+            'x509cert' => 'MIICgTCCAeoCCQCbOlrWDdX7FTANBgkqhkiG9w0BAQUFADCBhDELMAkGA1UEBhMCTk8xGDAWBgNVBAgTD0FuZHJlYXMgU29sYmVyZzEMMAoGA1UEBxMDRm9vMRAwDgYDVQQKEwdVTklORVRUMRgwFgYDVQQDEw9mZWlkZS5lcmxhbmcubm8xITAfBgkqhkiG9w0BCQEWEmFuZHJlYXNAdW5pbmV0dC5ubzAeFw0wNzA2MTUxMjAxMzVaFw0wNzA4MTQxMjAxMzVaMIGEMQswCQYDVQQGEwJOTzEYMBYGA1UECBMPQW5kcmVhcyBTb2xiZXJnMQwwCgYDVQQHEwNGb28xEDAOBgNVBAoTB1VOSU5FVFQxGDAWBgNVBAMTD2ZlaWRlLmVybGFuZy5ubzEhMB8GCSqGSIb3DQEJARYSYW5kcmVhc0B1bmluZXR0Lm5vMIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQDivbhR7P516x/S3BqKxupQe0LONoliupiBOesCO3SHbDrl3+q9IbfnfmE04rNuMcPsIxB161TdDpIesLCn7c8aPHISKOtPlAeTZSnb8QAu7aRjZq3+PbrP5uW3TcfCGPtKTytHOge/OlJbo078dVhXQ14d1EDwXJW1rRXuUt4C8QIDAQABMA0GCSqGSIb3DQEBBQUAA4GBACDVfp86HObqY+e8BUoWQ9+VMQx1ASDohBjwOsg2WykUqRXF+dLfcUH9dWR63CtZIKFDbStNomPnQz7nbK+onygwBspVEbnHuUihZq3ZUdmumQqCw4Uvs/1Uvq3orOo/WJVhTyvLgFVK2QarQ4/67OZfHd7R+POBXhophSMv1ZOo',
+        ),
+
+        'security' => array (
+            'authnRequestsSigned' => false,
+            'wantAssertionsSigned' => false,
+            'signMetadata' => false,
+        ),
+        'contactPerson' => array (
+            'technical' => array (
+                'givenName' => 'technical_name',
+                'emailAddress' => 'technical@example.com',
+            ),
+            'support' => array (
+                'givenName' => 'support_name',
+                'emailAddress' => 'support@example.com',
+            ),
+        ),
+
+        'organization' => array (
+            'en-US' => array(
+                'name' => 'sp_test',
+                'displayname' => 'SP test',
+                'url' => 'http://sp.example.com',
+            ),
+        ),
+    );

--- a/tests/src/OneLogin/Saml2/MetadataTest.php
+++ b/tests/src/OneLogin/Saml2/MetadataTest.php
@@ -58,6 +58,32 @@ class OneLogin_Saml2_MetadataTest extends PHPUnit_Framework_TestCase
     }
 
     /**
+    * Tests the builder method of the OneLogin_Saml2_Metadata
+    *
+    * @covers OneLogin_Saml2_Metadata::builder
+    */
+    public function testBuilderWithAttributeConsumingService()
+    {
+        $settingsDir = TEST_ROOT .'/settings/';
+        include $settingsDir.'settings3.php';
+        $settings = new OneLogin_Saml2_Settings($settingsInfo);
+        $spData = $settings->getSPData();
+        $security = $settings->getSecurityData();
+        $organization = $settings->getOrganization();
+        $contacts = $settings->getContacts();
+
+        $metadata = OneLogin_Saml2_Metadata::builder($spData, $security['authnRequestsSigned'], $security['wantAssertionsSigned'], null, null, $contacts, $organization);
+
+        $this->assertContains('<md:ServiceName xml:lang="en">Service Name</md:ServiceName>', $metadata);
+        $this->assertContains('<md:ServiceDescription xml:lang="en">Service Description</md:ServiceDescription>', $metadata);
+        $this->assertContains('<md:RequestedAttribute Name="FirstName" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri" isRequired="true"/>', $metadata);
+        $this->assertContains('<md:RequestedAttribute Name="LastName" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri" isRequired="true"/>', $metadata);
+
+        $result = \OneLogin_Saml2_Utils::validateXML($metadata, 'saml-schema-metadata-2.0.xsd');
+        $this->assertInstanceOf('DOMDocument', $result);
+    }
+
+    /**
     * Tests the signMetadata method of the OneLogin_Saml2_Metadata
     *
     * @covers OneLogin_Saml2_Metadata::signMetadata
@@ -90,7 +116,7 @@ class OneLogin_Saml2_MetadataTest extends PHPUnit_Framework_TestCase
         $this->assertContains('Location="http://stuff.com/endpoints/endpoints/acs.php"', $signedMetadata);
         $this->assertContains('<md:SingleLogoutService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect"', $signedMetadata);
         $this->assertContains(' Location="http://stuff.com/endpoints/endpoints/sls.php"/>', $signedMetadata);
-        
+
         $this->assertContains('<md:NameIDFormat>urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified</md:NameIDFormat>', $signedMetadata);
 
         $this->assertContains('<ds:SignedInfo><ds:CanonicalizationMethod Algorithm="http://www.w3.org/2001/10/xml-exc-c14n#"/>', $signedMetadata);


### PR DESCRIPTION
In the python lib of OneLogin the requested attributes are present https://github.com/onelogin/python-saml/blob/master/src/onelogin/saml2/metadata.py but not on the php library. This PR add requested  attributes if the user fills them.