### PR TITLE
Fix typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -289,7 +289,7 @@ $settings = array (
         // attributeConsumingService. nameFormat, attributeValue and
         // friendlyName can be omitted
         "attributeConsumingService"=> array(
-                "ServiceName" => "SP test",
+                "serviceName" => "SP test",
                 "serviceDescription" => "Test Service",
                 "requestedAttributes" => array(
                     array(


### PR DESCRIPTION
There is a typo in the configuration sample.