### PR TITLE
Default NameId for Logout Request: unspecified

### DIFF
--- a/lib/Saml2/LogoutRequest.php
+++ b/lib/Saml2/LogoutRequest.php
@@ -65,9 +65,9 @@ class OneLogin_Saml2_LogoutRequest
                 $nameIdFormat = $spData['NameIDFormat'];
                 $spNameQualifier = null;
             } else {
-                $nameId = $idpData['entityId'];
-                $nameIdFormat = OneLogin_Saml2_Constants::NAMEID_ENTITY;
-                $spNameQualifier = $spData['entityId'];
+                $nameId = null;
+                $nameIdFormat = OneLogin_Saml2_Constants::NAMEID_UNSPECIFIED;
+                $spNameQualifier = null;
             }
 
             $nameIdObj = OneLogin_Saml2_Utils::generateNameId(


### PR DESCRIPTION
The default format for an unspecified attribute nameID in the logout request was "entity". I think is better use "unspecified" by default and inject your nameID with your format when you need it.
