### PR TITLE
Improve NameIDFormat support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1131,6 +1131,7 @@ SAML 2 Authentication Response class
  * `getNameIdData` - Gets the NameID Data provided by the SAML response from the
    IdP.
  * `getNameId` - Gets the NameID provided by the SAML response from the IdP.
+ * `getNameIdFormat` - Gets the NameID Format provided by the SAML response from the IdP.
  * `getSessionNotOnOrAfter` - Gets the SessionNotOnOrAfter from the
    AuthnStatement
  * `getSessionIndex` - Gets the SessionIndex from the AuthnStatement.

--- a/demo1/index.php
+++ b/demo1/index.php
@@ -31,14 +31,19 @@ if (isset($_GET['sso'])) {
     $paramters = array();
     $nameId = null;
     $sessionIndex = null;
+    $nameIdFormat = null;
+
     if (isset($_SESSION['samlNameId'])) {
         $nameId = $_SESSION['samlNameId'];
     }
     if (isset($_SESSION['samlSessionIndex'])) {
         $sessionIndex = $_SESSION['samlSessionIndex'];
     }
+    if (isset($_SESSION['samlNameIdFormat'])) {
+        $nameIdFormat = $_SESSION['samlNameIdFormat'];
+    }
 
-    $auth->logout($returnTo, $paramters, $nameId, $sessionIndex);
+    $auth->logout($returnTo, $paramters, $nameId, $sessionIndex, false, $nameIdFormat);
 
     # If LogoutRequest ID need to be saved in order to later validate it, do instead
     # $sloBuiltUrl = $auth->logout(null, $paramters, $nameId, $sessionIndex, true);
@@ -70,6 +75,7 @@ if (isset($_GET['sso'])) {
 
     $_SESSION['samlUserdata'] = $auth->getAttributes();
     $_SESSION['samlNameId'] = $auth->getNameId();
+    $_SESSION['samlNameIdFormat'] = $auth->getNameIdFormat();
     $_SESSION['samlSessionIndex'] = $auth->getSessionIndex();
     unset($_SESSION['AuthNRequestID']);
     if (isset($_POST['RelayState']) && OneLogin_Saml2_Utils::getSelfURL() != $_POST['RelayState']) {

--- a/lib/Saml2/Auth.php
+++ b/lib/Saml2/Auth.php
@@ -29,6 +29,13 @@ class OneLogin_Saml2_Auth
     private $_nameid;
 
     /**
+     * NameID Format
+     *
+     * @var string
+     */
+    private $_nameidFormat;
+
+    /**
      * If user is authenticated.
      *
      * @var bool
@@ -126,6 +133,7 @@ class OneLogin_Saml2_Auth
             if ($response->isValid($requestId)) {
                 $this->_attributes = $response->getAttributes();
                 $this->_nameid = $response->getNameId();
+                $this->_nameidFormat = $response->getNameIdFormat();
                 $this->_authenticated = true;
                 $this->_sessionIndex = $response->getSessionIndex();
                 $this->_sessionExpiration = $response->getSessionNotOnOrAfter();
@@ -266,6 +274,16 @@ class OneLogin_Saml2_Auth
     }
 
     /**
+     * Returns the nameID Format
+     *
+     * @return string  The nameID Format of the assertion
+     */
+    public function getNameIdFormat()
+    {
+        return $this->_nameidFormat;
+    }
+
+    /**
      * Returns the SessionIndex
      *
      * @return string|null  The SessionIndex of the assertion
@@ -369,12 +387,13 @@ class OneLogin_Saml2_Auth
      * @param string|null $nameId        The NameID that will be set in the LogoutRequest.
      * @param string|null $sessionIndex  The SessionIndex (taken from the SAML Response in the SSO process).
      * @param bool        $stay          True if we want to stay (returns the url string) False to redirect
+     * @param string|null $nameIdFormat  The NameID Format will be set in the LogoutRequest.
      *
      * @return If $stay is True, it return a string with the SLO URL + LogoutRequest + parameters
      *
      * @throws OneLogin_Saml2_Error
      */
-    public function logout($returnTo = null, $parameters = array(), $nameId = null, $sessionIndex = null, $stay=false)
+    public function logout($returnTo = null, $parameters = array(), $nameId = null, $sessionIndex = null, $stay=false, $nameIdFormat = null)
     {
         assert('is_array($parameters)');
 
@@ -390,7 +409,7 @@ class OneLogin_Saml2_Auth
             $nameId = $this->_nameid;
         }
 
-        $logoutRequest = new OneLogin_Saml2_LogoutRequest($this->_settings, null, $nameId, $sessionIndex);
+        $logoutRequest = new OneLogin_Saml2_LogoutRequest($this->_settings, null, $nameId, $sessionIndex, $nameIdFormat);
 
         $this->_lastRequestID = $logoutRequest->id;
 

--- a/lib/Saml2/LogoutRequest.php
+++ b/lib/Saml2/LogoutRequest.php
@@ -34,12 +34,13 @@ class OneLogin_Saml2_LogoutRequest
     /**
      * Constructs the Logout Request object.
      *
-     * @param OneLogin_Saml2_Settings $settings Settings
-     * @param string|null             $request A UUEncoded Logout Request.
-     * @param string|null             $nameId   The NameID that will be set in the LogoutRequest.
-     * @param string|null             $sessionIndex  The SessionIndex (taken from the SAML Response in the SSO process).
+     * @param OneLogin_Saml2_Settings $settings     Settings
+     * @param string|null             $request      A UUEncoded Logout Request.
+     * @param string|null             $nameId       The NameID that will be set in the LogoutRequest.
+     * @param string|null             $sessionIndex The SessionIndex (taken from the SAML Response in the SSO process).
+     * @param string|null             $nameIdFormat The NameID Format will be set in the LogoutRequest.
      */
-    public function __construct(OneLogin_Saml2_Settings $settings, $request = null, $nameId = null, $sessionIndex = null)
+    public function __construct(OneLogin_Saml2_Settings $settings, $request = null, $nameId = null, $sessionIndex = null, $nameIdFormat = null)
     {
 
         $this->_settings = $settings;
@@ -62,7 +63,9 @@ class OneLogin_Saml2_LogoutRequest
             }
 
             if (!empty($nameId)) {
-                $nameIdFormat = $spData['NameIDFormat'];
+                if (empty($nameIdFormat)) {
+                    $nameIdFormat = $spData['NameIDFormat'];
+                }
                 $spNameQualifier = null;
             } else {
                 $nameId = $idpData['entityId'];

--- a/lib/Saml2/Response.php
+++ b/lib/Saml2/Response.php
@@ -480,6 +480,21 @@ class OneLogin_Saml2_Response
     }
 
     /**
+     * Gets the NameID Format provided by the SAML response from the IdP.
+     *
+     * @return string Name ID Format
+     */
+    public function getNameIdFormat()
+    {
+        $nameIdFormat = null;
+        $nameIdData = $this->getNameIdData();
+        if (!empty($nameIdData) && isset($nameIdData['Format'])) {
+            $nameIdFormat = $nameIdData['Format'];
+        }
+        return $nameIdFormat;
+    }
+
+    /**
      * Gets the SessionNotOnOrAfter from the AuthnStatement.
      * Could be used to set the local session expiration
      * 

--- a/tests/src/OneLogin/Saml2/AuthTest.php
+++ b/tests/src/OneLogin/Saml2/AuthTest.php
@@ -90,6 +90,7 @@ class OneLogin_Saml2_AuthTest extends PHPUnit_Framework_TestCase
     * @covers OneLogin_Saml2_Auth::getAttributes
     * @covers OneLogin_Saml2_Auth::getAttribute
     * @covers OneLogin_Saml2_Auth::getNameId
+    * @covers OneLogin_Saml2_Auth::getNameIdFormat
     * @covers OneLogin_Saml2_Auth::getErrors
     * @covers OneLogin_Saml2_Auth::getSessionIndex
     * @covers OneLogin_Saml2_Auth::getSessionExpiration
@@ -105,6 +106,7 @@ class OneLogin_Saml2_AuthTest extends PHPUnit_Framework_TestCase
         $this->assertFalse($this->_auth->isAuthenticated());
         $this->assertEmpty($this->_auth->getAttributes());
         $this->assertNull($this->_auth->getNameId());
+        $this->assertNull($this->_auth->getNameIdFormat());
         $this->assertNull($this->_auth->getSessionIndex());
         $this->assertNull($this->_auth->getSessionExpiration());
         $this->assertNull($this->_auth->getAttribute('uid'));
@@ -153,6 +155,7 @@ class OneLogin_Saml2_AuthTest extends PHPUnit_Framework_TestCase
     * @covers OneLogin_Saml2_Auth::getAttributes
     * @covers OneLogin_Saml2_Auth::getAttribute
     * @covers OneLogin_Saml2_Auth::getNameId
+    * @covers OneLogin_Saml2_Auth::getNameIdFormat
     * @covers OneLogin_Saml2_Auth::getSessionIndex
     * @covers OneLogin_Saml2_Auth::getSessionExpiration
     * @covers OneLogin_Saml2_Auth::getErrors
@@ -165,6 +168,7 @@ class OneLogin_Saml2_AuthTest extends PHPUnit_Framework_TestCase
         $this->_auth->processResponse();
         $this->assertTrue($this->_auth->isAuthenticated());
         $this->assertEquals('492882615acf31c8096b627245d76ae53036c090', $this->_auth->getNameId());
+        $this->assertEquals('urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress', $this->_auth->getNameIdFormat());
         $attributes = $this->_auth->getAttributes();
         $this->assertNotEmpty($attributes);
         $this->assertEquals($this->_auth->getAttribute('mail'), $attributes['mail']);

--- a/tests/src/OneLogin/Saml2/ResponseTest.php
+++ b/tests/src/OneLogin/Saml2/ResponseTest.php
@@ -135,6 +135,35 @@ class OneLogin_Saml2_ResponseTest extends PHPUnit_Framework_TestCase
     }
 
     /**
+    * Tests the getNameIdFormat method of the OneLogin_Saml2_Response
+    *
+    * @covers OneLogin_Saml2_Response::getNameIdFormat
+    */
+    public function testGetNameIdFormat()
+    {
+        $xml = file_get_contents(TEST_ROOT . '/data/responses/response1.xml.base64');
+        $response = new OneLogin_Saml2_Response($this->_settings, $xml);
+        $this->assertEquals('urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress', $response->getNameIdFormat());
+
+        $xml2 = file_get_contents(TEST_ROOT . '/data/responses/response_encrypted_nameid.xml.base64');
+        $response2 = new OneLogin_Saml2_Response($this->_settings, $xml2);
+        $this->assertEquals('urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified', $response2->getNameIdFormat());
+    
+        $xml3 = file_get_contents(TEST_ROOT . '/data/responses/valid_encrypted_assertion.xml.base64');
+        $response3 = new OneLogin_Saml2_Response($this->_settings, $xml3);
+        $this->assertEquals('urn:oasis:names:tc:SAML:2.0:nameid-format:transient', $response3->getNameIdFormat());
+
+        $xml4 = file_get_contents(TEST_ROOT . '/data/responses/invalids/no_nameid.xml.base64');
+        $response4 = new OneLogin_Saml2_Response($this->_settings, $xml4);
+
+        try {
+            $nameId4 = $response4->getNameIdFormat();
+        } catch (Exception $e) {
+            $this->assertContains('Not NameID found in the assertion of the Response', $e->getMessage());
+        }
+    }
+
+    /**
     * Tests the getNameIdData method of the OneLogin_Saml2_Response
     *
     * @covers OneLogin_Saml2_Response::getNameIdData


### PR DESCRIPTION
I extended the LogoutRequest constructor in order to be able to provide a NameIdFormat, so I added getNameIDFormat methods to the Auth and SAMLResponse class, and added the NameIdFormat parameter to the logout method.

I have doubts about providing the NameIdData so 'SPNameQualifier' and 'NameQualifier' to the LogoutRequest constructor instead of just the NameIdFormat, so I can set those values there.

Before merge, I want to hear feedback from community.
