### PR TITLE
Fixing issue when object is passed into the settings constructor

### DIFF
--- a/lib/Saml2/Settings.php
+++ b/lib/Saml2/Settings.php
@@ -119,7 +119,17 @@ class OneLogin_Saml2_Settings
                 );
             }
         } else {
-            if (!$this->_loadSettingsFromArray($settings->getValues())) {
+
+            // JV: If this was an object, we want convert it to an array as expected.
+            if (is_object($settings)) {
+                $tmp = [];
+                foreach ( get_object_vars($settings) as $k => $v ) {
+                    $tmp[trim($k,'_')] = $v;
+                }
+                $settings = $tmp;
+            }
+
+            if (!$this->_loadSettingsFromArray($settings)) {
                 throw new OneLogin_Saml2_Error(
                     'Invalid array settings: %s',
                     OneLogin_Saml2_Error::SETTINGS_INVALID,
@@ -772,14 +782,14 @@ class OneLogin_Saml2_Settings
 
                 if (!$keyMetadata) {
                     throw new OneLogin_Saml2_Error(
-                        'SP Private key not found.',
+                        'Private key not found.',
                         OneLogin_Saml2_Error::PRIVATE_KEY_FILE_NOT_FOUND
                     );
                 }
 
                 if (!$certMetadata) {
                     throw new OneLogin_Saml2_Error(
-                        'SP Public cert not found.',
+                        'Public cert file not found.',
                         OneLogin_Saml2_Error::PUBLIC_CERT_FILE_NOT_FOUND
                     );
                 }
@@ -801,7 +811,7 @@ class OneLogin_Saml2_Settings
 
                 if (!file_exists($keyMetadataFile)) {
                     throw new OneLogin_Saml2_Error(
-                        'SP Private key file not found: %s',
+                        'Private key file not found: %s',
                         OneLogin_Saml2_Error::PRIVATE_KEY_FILE_NOT_FOUND,
                         array($keyMetadataFile)
                     );
@@ -809,7 +819,7 @@ class OneLogin_Saml2_Settings
 
                 if (!file_exists($certMetadataFile)) {
                     throw new OneLogin_Saml2_Error(
-                        'SP Public cert file not found: %s',
+                        'Public cert file not found: %s',
                         OneLogin_Saml2_Error::PUBLIC_CERT_FILE_NOT_FOUND,
                         array($certMetadataFile)
                     );

--- a/lib/Saml2/Settings.php
+++ b/lib/Saml2/Settings.php
@@ -782,14 +782,14 @@ class OneLogin_Saml2_Settings
 
                 if (!$keyMetadata) {
                     throw new OneLogin_Saml2_Error(
-                        'Private key not found.',
+                        'SP Private key not found.',
                         OneLogin_Saml2_Error::PRIVATE_KEY_FILE_NOT_FOUND
                     );
                 }
 
                 if (!$certMetadata) {
                     throw new OneLogin_Saml2_Error(
-                        'Public cert file not found.',
+                        'SP Public cert not found.',
                         OneLogin_Saml2_Error::PUBLIC_CERT_FILE_NOT_FOUND
                     );
                 }
@@ -811,7 +811,7 @@ class OneLogin_Saml2_Settings
 
                 if (!file_exists($keyMetadataFile)) {
                     throw new OneLogin_Saml2_Error(
-                        'Private key file not found: %s',
+                        'SP Private key file not found: %s',
                         OneLogin_Saml2_Error::PRIVATE_KEY_FILE_NOT_FOUND,
                         array($keyMetadataFile)
                     );
@@ -819,7 +819,7 @@ class OneLogin_Saml2_Settings
 
                 if (!file_exists($certMetadataFile)) {
                     throw new OneLogin_Saml2_Error(
-                        'Public cert file not found: %s',
+                        'SP Public cert file not found: %s',
                         OneLogin_Saml2_Error::PUBLIC_CERT_FILE_NOT_FOUND,
                         array($certMetadataFile)
                     );


### PR DESCRIPTION
In a case like this:

```
$samlSettings = new \OneLogin_Saml2_Settings($settingsInfo);
$auth = new \OneLogin_Saml2_Auth($samlSettings);
```

The settings constructor bombs if it is an object. This hack converts a well formed object into a well formed settings array.

I also note that the `$settings->getValues()` function does not exist within the saml2 code base, so the real fix may be to add a working version of that (the saml version does not seem to solve the issue).