### PR TITLE
Allow overriding of host, port, protocol nsdr url path for URL building

### DIFF
--- a/README.md
+++ b/README.md
@@ -279,6 +279,12 @@ $settings = array (
     // Enable debug mode (to print errors).
     'debug' => false,
 
+    // Set a BaseURL to be used instead of try to guess
+    // the BaseURL of the view that process the SAML Message.
+    // Ex http://sp.example.com/
+    //    http://example.com/sp/ 
+    'baseurl' => null,
+
     // Service Provider Data that we are deploying.
     'sp' => array (
         // Identifier of the SP entity  (must be a URI)
@@ -1035,6 +1041,26 @@ if (isset($_SESSION['samlUserdata'])) {   // If there is user data we print it.
 }
 ```
 
+#### URL-guessing methods ####
+ 
+php-saml toolkit uses a bunch of methods in OneLogin_Saml2_Utils that try to guess the URL where the SAML messages are processed.
+
+* `getSelfHost` Returns the current host.
+* `getSelfPort` Return the port number used for the request
+* `isHTTPS` Checks if the protocol is https or http.
+* `getSelfURLhost` Returns the protocol + the current host + the port (if different than common ports).
+* `getSelfURL` Returns the URL of the current host + current view + query.
+* `getSelfURLNoQuery` Returns the URL of the current host + current view.
+* `getSelfRoutedURLNoQuery` Returns the routed URL of the current host + current view.
+
+getSelfURLNoQuery and getSelfRoutedURLNoQuery are used to calculate the currentURL in order to valdate SAML elements like Destination or Recipient.
+
+When the PHP application is behind a proxy or a load balancer we can execute setProxyVars(true) and getSelfPort and isHTTPS will take care of the $_SERVER["HTTP_X_FORWARDED_PORT"] and $_SERVER['HTTP_X_FORWARDED_PROTO'] vars (otherwise they are ignored).
+
+Also a developer can use setSelfProtocol, setSelfHost, setSelfPort and getBaseURLPath to define a specific value to be returned by isHTTPS, getSelfHost, getSelfPort and getBaseURLPath. And define a setBasePath to be used on the getSelfURL and getSelfRoutedURLNoQuery to replace the data extracted from $_SERVER["REQUEST_URI"].
+
+At the settings the developer will be able to set a 'baseurl' parameter that automatically will use setBaseURL to set values for setSelfProtocol, setSelfHost, setSelfPort and setBaseURLPath.
+
 ### Main classes and methods ###
 
 Described below are the main classes and methods that can be invoked.
@@ -1196,7 +1222,9 @@ Configuration of the OneLogin PHP Toolkit
  * `formatSPKey` - Formats the SP private key.
  * `getErrors` - Returns an array with the errors, the array is empty when
    the settings is ok.
- * `getLastErrorReason`* Returns the reason of the last error
+ * `getLastErrorReason` - Returns the reason of the last error
+ * `getBaseURL` -  Returns the baseurl set on the settings if any.
+ * `setBaseURL` - Set a baseurl value
  * `setStrict` - Activates or deactivates the strict mode.
  * `isStrict` - Returns if the 'strict' mode is active.
  * `isDebugActive` - Returns if the debug is active.

--- a/lib/Saml2/LogoutRequest.php
+++ b/lib/Saml2/LogoutRequest.php
@@ -41,8 +41,12 @@ class OneLogin_Saml2_LogoutRequest
      */
     public function __construct(OneLogin_Saml2_Settings $settings, $request = null, $nameId = null, $sessionIndex = null)
     {
-
         $this->_settings = $settings;
+
+        if (!empty($this->_settings->getBaseURL())) {
+            $baseURL = $this->_settings->getBaseURL();
+            OneLogin_Saml2_Utils::setBaseURL($baseURL);
+        }
 
         if (!isset($request) || empty($request)) {
 

--- a/lib/Saml2/LogoutRequest.php
+++ b/lib/Saml2/LogoutRequest.php
@@ -43,8 +43,8 @@ class OneLogin_Saml2_LogoutRequest
     {
         $this->_settings = $settings;
 
-        if (!empty($this->_settings->getBaseURL())) {
-            $baseURL = $this->_settings->getBaseURL();
+        $baseURL = $this->_settings->getBaseURL();
+        if (!empty($baseURL)) {
             OneLogin_Saml2_Utils::setBaseURL($baseURL);
         }
 

--- a/lib/Saml2/LogoutResponse.php
+++ b/lib/Saml2/LogoutResponse.php
@@ -42,8 +42,8 @@ class OneLogin_Saml2_LogoutResponse
     {
         $this->_settings = $settings;
 
-        if (!empty($this->_settings->getBaseURL())) {
-            $baseURL = $this->_settings->getBaseURL();
+        $baseURL = $this->_settings->getBaseURL();
+        if (!empty($baseURL)) {
             OneLogin_Saml2_Utils::setBaseURL($baseURL);
         }
 

--- a/lib/Saml2/LogoutResponse.php
+++ b/lib/Saml2/LogoutResponse.php
@@ -41,6 +41,12 @@ class OneLogin_Saml2_LogoutResponse
     public function __construct(OneLogin_Saml2_Settings $settings, $response = null)
     {
         $this->_settings = $settings;
+
+        if (!empty($this->_settings->getBaseURL())) {
+            $baseURL = $this->_settings->getBaseURL();
+            OneLogin_Saml2_Utils::setBaseURL($baseURL);
+        }
+
         if ($response) {
             $decoded = base64_decode($response);
             $inflated = @gzinflate($decoded);

--- a/lib/Saml2/Response.php
+++ b/lib/Saml2/Response.php
@@ -56,6 +56,11 @@ class OneLogin_Saml2_Response
     {
         $this->_settings = $settings;
 
+        if (!empty($this->_settings->getBaseURL())) {
+            $baseURL = $this->_settings->getBaseURL();
+            OneLogin_Saml2_Utils::setBaseURL($baseURL);
+        }
+
         $this->response = base64_decode($response);
 
         $this->document = new DOMDocument();

--- a/lib/Saml2/Response.php
+++ b/lib/Saml2/Response.php
@@ -56,8 +56,8 @@ class OneLogin_Saml2_Response
     {
         $this->_settings = $settings;
 
-        if (!empty($this->_settings->getBaseURL())) {
-            $baseURL = $this->_settings->getBaseURL();
+        $baseURL = $this->_settings->getBaseURL();
+        if (!empty($baseURL)) {
             OneLogin_Saml2_Utils::setBaseURL($baseURL);
         }
 

--- a/lib/Saml2/Settings.php
+++ b/lib/Saml2/Settings.php
@@ -15,6 +15,11 @@ class OneLogin_Saml2_Settings
     private $_paths = array();
 
     /**
+     * @var string
+     */
+    private  $_baseurl;
+
+    /**
      * Strict. If active, PHP Toolkit will reject unsigned or unencrypted messages
      * if it expects them signed or encrypted. If not, the messages will be accepted
      * and some security issues will be also relaxed.
@@ -238,6 +243,10 @@ class OneLogin_Saml2_Settings
             }
             if (isset($settings['debug'])) {
                 $this->_debug = $settings['debug'];
+            }
+
+            if (isset($settings['baseurl'])) {
+                $this->_baseurl = $settings['baseurl'];
             }
 
             if (isset($settings['compress'])) {
@@ -938,6 +947,24 @@ class OneLogin_Saml2_Settings
     public function isDebugActive()
     {
         return $this->_debug;
+    }
+
+    /**
+     * Set a baseurl value.
+     */
+    public function setBaseURL($baseurl)
+    {
+        $this->_baseurl = $baseurl;
+    }
+
+    /**
+     * Returns the baseurl set on the settings if any.
+     *
+     * @return null|string The baseurl
+     */
+    public function getBaseURL()
+    {
+        return $this->_baseurl;
     }
 
     /**

--- a/lib/Saml2/Utils.php
+++ b/lib/Saml2/Utils.php
@@ -565,7 +565,7 @@ class OneLogin_Saml2_Utils
         }
 
         if (!empty(self::getBaseURLPath())) {
-            if (!empty($route)){
+            if (!empty($route)) {
                 $path = explode('/', $route);
                 $route = self::getBaseURLPath();
                 $script = array_pop($path);
@@ -599,7 +599,7 @@ class OneLogin_Saml2_Utils
         }
 
         if (!empty(self::getBaseURLPath())) {
-            if (!empty($requestURI)){
+            if (!empty($requestURI)) {
                 $path = explode('/', $requestURI);
                 $requestURI = self::getBaseURLPath();
                 $scriptAndQuery = array_pop($path);

--- a/settings_example.php
+++ b/settings_example.php
@@ -10,6 +10,12 @@ $settings = array (
     // Enable debug mode (to print errors)
     'debug' => false,
 
+    // Set a BaseURL to be used instead of try to guess 
+    // the BaseURL of the view that process the SAML Message.
+    // Ex. http://sp.example.com/
+    //     http://example.com/sp/ 
+    'baseurl' => null,
+
     // Service Provider Data that we are deploying
     'sp' => array (
         // Identifier of the SP entity  (must be a URI)

--- a/tests/src/OneLogin/Saml2/UtilsTest.php
+++ b/tests/src/OneLogin/Saml2/UtilsTest.php
@@ -351,10 +351,18 @@ class OneLogin_Saml2_UtilsTest extends PHPUnit_Framework_TestCase
     public function testisHTTPS()
     {
         $this->assertFalse(OneLogin_Saml2_Utils::isHTTPS());
+        
+        $_SERVER['HTTPS'] = 'on';
+        $this->assertTrue(OneLogin_Saml2_Utils::isHTTPS());
+    
+        unset($_SERVER['HTTPS']);
+        $this->assertFalse(OneLogin_Saml2_Utils::isHTTPS());
+        $_SERVER['HTTP_HOST'] = 'example.com:443';
+        $this->assertTrue(OneLogin_Saml2_Utils::isHTTPS());
     }
 
     /**
-     * @covers OneLogin_Saml2_Utils::getSelfURLhost()
+     * @covers OneLogin_Saml2_Utils::getSelfURLhost
      */
     public function testGetselfurlhostdoubleport()
     {
@@ -369,7 +377,7 @@ class OneLogin_Saml2_UtilsTest extends PHPUnit_Framework_TestCase
     }
 
     /**
-     * @covers OneLogin_Saml2_Utils::getSelfPort()
+     * @covers OneLogin_Saml2_Utils::getSelfPort
      */
     public function testGetselfPort()
     {
@@ -395,7 +403,7 @@ class OneLogin_Saml2_UtilsTest extends PHPUnit_Framework_TestCase
     }
 
     /**
-     * @covers OneLogin_Saml2_Utils::setSelfProtocol()
+     * @covers OneLogin_Saml2_Utils::setSelfProtocol
      */
     public function testSetselfprotocol()
     {
@@ -403,6 +411,74 @@ class OneLogin_Saml2_UtilsTest extends PHPUnit_Framework_TestCase
 
         OneLogin_Saml2_Utils::setSelfProtocol('https');
         $this->assertTrue(OneLogin_Saml2_Utils::isHTTPS());
+    }
+
+    /**
+     * @covers OneLogin_Saml2_Utils::setBaseURLPath
+     */
+    public function testSetBaseURLPath()
+    {
+        $this->assertNull(OneLogin_Saml2_Utils::getBaseURLPath());
+
+        OneLogin_Saml2_Utils::setBaseURLPath('sp');
+        $this->assertEquals('/sp/', OneLogin_Saml2_Utils::getBaseURLPath());
+
+        OneLogin_Saml2_Utils::setBaseURLPath('sp/');
+        $this->assertEquals('/sp/', OneLogin_Saml2_Utils::getBaseURLPath());
+
+        OneLogin_Saml2_Utils::setBaseURLPath('/sp');
+        $this->assertEquals('/sp/', OneLogin_Saml2_Utils::getBaseURLPath());
+
+        OneLogin_Saml2_Utils::setBaseURLPath('/sp/');
+        $this->assertEquals('/sp/', OneLogin_Saml2_Utils::getBaseURLPath());
+    }
+
+    /**
+     * @covers OneLogin_Saml2_Utils::setBaseURL
+     */
+    public function testSetBaseURL()
+    {
+        $_SERVER['HTTP_HOST'] = 'sp.example.com';
+        $_SERVER['HTTPS'] = 'https';
+        $_SERVER['REQUEST_URI'] = '/example1/route.php?x=test';
+        $_SERVER['QUERY_STRING'] = '?x=test';
+        $_SERVER['SCRIPT_NAME'] = '/example1/route.php';
+        unset($_SERVER['PATH_INFO']);
+
+        $expectedUrlNQ = 'https://sp.example.com/example1/route.php';
+        $expectedRoutedUrlNQ = 'https://sp.example.com/example1/route.php';
+        $expectedUrl = 'https://sp.example.com/example1/route.php?x=test';
+
+        OneLogin_Saml2_Utils::setBaseURL("no-valid-url");
+        $this->assertEquals('https', OneLogin_Saml2_Utils::getSelfProtocol());
+        $this->assertEquals('sp.example.com', OneLogin_Saml2_Utils::getSelfHost());
+        $this->assertNull(OneLogin_Saml2_Utils::getSelfPort());
+        $this->assertNull(OneLogin_Saml2_Utils::getBaseURLPath());
+
+        $this->assertEquals($expectedUrlNQ, OneLogin_Saml2_Utils::getSelfURLNoQuery());       
+        $this->assertEquals($expectedRoutedUrlNQ, OneLogin_Saml2_Utils::getSelfRoutedURLNoQuery());
+        $this->assertEquals($expectedUrl, OneLogin_Saml2_Utils::getSelfURL());
+
+        OneLogin_Saml2_Utils::setBaseURL("http://anothersp.example.com:81/example2/");
+        $expectedUrlNQ2 = 'http://anothersp.example.com:81/example2/route.php';
+        $expectedRoutedUrlNQ2 = 'http://anothersp.example.com:81/example2/route.php';
+        $expectedUrl2 = 'http://anothersp.example.com:81/example2/route.php?x=test';
+        
+        $this->assertEquals('http', OneLogin_Saml2_Utils::getSelfProtocol());
+        $this->assertEquals('anothersp.example.com', OneLogin_Saml2_Utils::getSelfHost());
+        $this->assertEquals('81', OneLogin_Saml2_Utils::getSelfPort());
+        $this->assertEquals('/example2/', OneLogin_Saml2_Utils::getBaseURLPath());
+
+        $this->assertEquals($expectedUrlNQ2, OneLogin_Saml2_Utils::getSelfURLNoQuery());       
+        $this->assertEquals($expectedRoutedUrlNQ2, OneLogin_Saml2_Utils::getSelfRoutedURLNoQuery());
+        $this->assertEquals($expectedUrl2, OneLogin_Saml2_Utils::getSelfURL());
+
+        $_SERVER['PATH_INFO'] = '/test';
+        $expectedUrlNQ2 = 'http://anothersp.example.com:81/example2/route.php/test';
+
+        $this->assertEquals($expectedUrlNQ2, OneLogin_Saml2_Utils::getSelfURLNoQuery());       
+        $this->assertEquals($expectedRoutedUrlNQ2, OneLogin_Saml2_Utils::getSelfRoutedURLNoQuery());
+        $this->assertEquals($expectedUrl2, OneLogin_Saml2_Utils::getSelfURL());
     }
 
     /**


### PR DESCRIPTION
A developer can use setSelfProtocol, setSelfHost, setSelfPort and getBaseURLPath to define a specific value to be returned by isHTTPS, getSelfHost, getSelfPort and getBaseURLPath. And define a setBasePath to be used on the getSelfURL and getSelfRoutedURLNoQuery to replace the data extracted from $_SERVER["REQUEST_URI"].

At the settings the developer will be able to set a 'baseurl' parameter that automatically will use setBaseURL to set values for setSelfProtocol, setSelfHost, setSelfPort and setBaseURLPath.