### PR TITLE
Add error message for bad OneLogin_Saml2_Settings argument

### DIFF
--- a/lib/Saml2/Settings.php
+++ b/lib/Saml2/Settings.php
@@ -100,6 +100,7 @@ class OneLogin_Saml2_Settings
      * @param array|object|null $settings SAML Toolkit Settings
      *
      * @throws OneLogin_Saml2_Error If any settings parameter is invalid
+     * @throws Exception If OneLogin_Saml2_Settings is incorrectly supplied
      */
     public function __construct($settings = null, $spValidationOnly = false)
     {
@@ -123,6 +124,8 @@ class OneLogin_Saml2_Settings
                     array(implode(', ', $this->_errors))
                 );
             }
+        } else if ($settings instanceof OneLogin_Saml2_Settings) {
+            throw new Exception('Only instances of OneLogin_Saml_Settings are supported.');
         } else {
             if (!$this->_loadSettingsFromArray($settings->getValues())) {
                 throw new OneLogin_Saml2_Error(


### PR DESCRIPTION
https://github.com/onelogin/php-saml/issues/176

In the issue above, I was incorrectly supplying a OneLogin_Saml2_Settings object to a OneLogin_Saml2_Settings object, when only a OneLogin_Saml_Settings object is supported. The docs are clear in this regard, but the runtime error message could be a little more clear to prevent any future confusion.

Thanks!