### PR TITLE
Fix strpos bug when decrypting assertions

### DIFF
--- a/lib/Saml2/Response.php
+++ b/lib/Saml2/Response.php
@@ -1001,7 +1001,7 @@ class OneLogin_Saml2_Response
 
                 if (strpos($encryptedAssertion->tagName, 'saml2:') !== false) {
                     $ns = 'xmlns:saml2';
-                } else if (strpos($encryptedAssertion->tagName, 'saml:') != false) {
+                } else if (strpos($encryptedAssertion->tagName, 'saml:') !== false) {
                     $ns = 'xmlns:saml';
                 } else {
                     $ns = 'xmlns';


### PR DESCRIPTION
Issue introduced in https://github.com/onelogin/php-saml/commit/994cacb85e419a289b6fff727eb068109e7f4591

`strpos` returns 1st occurence of characters in a string, in this case 0, which evaluates to false so the correct namespace is not applied. This causes assertion signatures to fail with the error 'Reference validation failed'.