### PR TITLE
Add invalid entityId to Exception

### DIFF
--- a/lib/Saml2/Response.php
+++ b/lib/Saml2/Response.php
@@ -256,7 +256,7 @@ class OneLogin_Saml2_Response
                     $trimmedIssuer = trim($issuer);
                     if (empty($trimmedIssuer) || $trimmedIssuer !== $idPEntityId) {
                         throw new OneLogin_Saml2_ValidationError(
-                            "Invalid issuer in the Assertion/Response",
+                            "Invalid issuer in the Assertion/Response (expected '$idPEntityId', got '$trimmedIssuer')",
                             OneLogin_Saml2_ValidationError::WRONG_ISSUER
                         );
                     }

--- a/tests/src/OneLogin/Saml2/ResponseTest.php
+++ b/tests/src/OneLogin/Saml2/ResponseTest.php
@@ -952,12 +952,12 @@ class OneLogin_Saml2_ResponseTest extends PHPUnit_Framework_TestCase
         $response3 = new OneLogin_Saml2_Response($this->_settings, $message);
 
         $this->assertFalse($response3->isValid());
-        $this->assertEquals('Invalid issuer in the Assertion/Response', $response3->getError());
+        $this->assertEquals('Invalid issuer in the Assertion/Response (expected \'http://idp.example.com/\', got \'http://invalid.issuer.example.com/\')', $response3->getError());
 
         $response4 = new OneLogin_Saml2_Response($this->_settings, $message2);
 
         $this->assertFalse($response4->isValid());
-        $this->assertEquals('Invalid issuer in the Assertion/Response', $response4->getError());
+        $this->assertEquals('Invalid issuer in the Assertion/Response (expected \'http://idp.example.com/\', got \'http://invalid.isser.example.com/\')', $response4->getError());
     }
 
     /**


### PR DESCRIPTION
This makes debugging issues with the entityID easier as the correct one and the supplied one can easily be compared. 

Signed-off-by: Lukas Reschke <lukas@statuscode.ch>

Ref https://github.com/nextcloud/user_saml/issues/83