### PR TITLE
Fixed issue with undefined constant of UNEXPECTED_SIGNED_ELEMENT

### DIFF
--- a/lib/Saml2/Response.php
+++ b/lib/Saml2/Response.php
@@ -772,7 +772,7 @@ class OneLogin_Saml2_Response
             if (!$this->validateSignedElements($signedElements)) {
                 throw new OneLogin_Saml2_ValidationError(
                     'Found an unexpected Signature Element. SAML Response rejected',
-                    OneLogin_Saml2_ValidationError::UNEXPECTED_SIGNED_ELEMENT
+                    OneLogin_Saml2_ValidationError::UNEXPECTED_SIGNED_ELEMENTS
                 );
             }
         }


### PR DESCRIPTION
The constant had been used incorrectly, as it had been defined as UNEXPECTED_SIGNED_ELEMENTS.

This meant if the error had to be thrown then a 500 would instead be generated.