### PR TITLE
Allow multiple IDP certificates in the settings object

### DIFF
--- a/lib/Saml2/Settings.php
+++ b/lib/Saml2/Settings.php
@@ -894,7 +894,13 @@ class OneLogin_Saml2_Settings
     public function formatIdPCert()
     {
         if (isset($this->_idp['x509cert'])) {
-            $this->_idp['x509cert'] = OneLogin_Saml2_Utils::formatCert($this->_idp['x509cert']);
+			if(is_array($this->_idp['x509cert'])) {
+				$certs = $this->_idp['x509cert'];
+				$this->_idp['x509cert'] = array();
+				foreach($certs as $cert) $this->_idp['x509cert'][] = OneLogin_Saml2_Utils::formatCert($cert);
+			} else {
+				$this->_idp['x509cert'] = OneLogin_Saml2_Utils::formatCert($this->_idp['x509cert']);
+			}
         }
     }
 

--- a/lib/Saml2/Utils.php
+++ b/lib/Saml2/Utils.php
@@ -1302,8 +1302,19 @@ class OneLogin_Saml2_Utils
         }
 
         XMLSecEnc::staticLocateKeyInfo($objKey, $objDSig);
-
+		
         if (!empty($cert)) {
+			if(is_array($cert)) {
+				// Find the certificate that matches the request, if there is one
+				$domCert = $objKey->getX509Certificate();
+				$matching_cert = null;
+				
+				foreach($cert as $single_cert) {
+					if($single_cert == $domCert) { $matching_cert = $single_cert; break; }
+				}
+				$cert = $matching_cert;
+				if(null == $cert) { return false; }	// No matching cert
+			}
             $objKey->loadKey($cert, false, true);
             return ($objXMLSecDSig->verify($objKey) === 1);
         } else {


### PR DESCRIPTION
Allow multiple IDP certificates in the settings object, and select the right one to verify the signature on a signed SAML response, based on what the document says it used.