### PR TITLE
Fix wording

### DIFF
--- a/README.md
+++ b/README.md
@@ -1085,9 +1085,9 @@ You should be able to workaround this by configuring your server so that it is a
 Or by using the method described on the previous section.
 
 
-### Reply attacks ###
+### Replay attacks ###
 
-In order to avoid reply attacks, you can store the ID of the SAML messages already processed, to avoid processing them twice. Since the Messages expires and will be invalidated due that fact, you don't need to store those IDs longer than the time frame that you currently accepting.
+In order to avoid replay attacks, you can store the ID of the SAML messages already processed, to avoid processing them twice. Since the Messages expires and will be invalidated due that fact, you don't need to store those IDs longer than the time frame that you currently accepting.
 
 Get the ID of the last processed message/assertion with the getLastMessageId/getLastAssertionId method of the Auth object.
 


### PR DESCRIPTION
I suppose this should be "Reply attacks" instead of "Reply attacks"

Signed-off-by: Lukas Reschke <lukas@statuscode.ch>