### PR TITLE
Update validation to allow URL's that don't conform to RFC 2396

### DIFF
--- a/lib/Saml2/Settings.php
+++ b/lib/Saml2/Settings.php
@@ -512,14 +512,14 @@ class OneLogin_Saml2_Settings
                 || empty($idp['singleSignOnService']['url'])
             ) {
                 $errors[] = 'idp_sso_not_found';
-            } else if (!filter_var($idp['singleSignOnService']['url'], FILTER_VALIDATE_URL)) {
+            } else if (!OneLogin_Saml2_Utils::validateUrl($idp['singleSignOnService']['url'])) {
                 $errors[] = 'idp_sso_url_invalid';
             }
 
             if (isset($idp['singleLogoutService'])
                 && isset($idp['singleLogoutService']['url'])
                 && !empty($idp['singleLogoutService']['url'])
-                && !filter_var($idp['singleLogoutService']['url'], FILTER_VALIDATE_URL)
+                && !OneLogin_Saml2_Utils::validateUrl($idp['singleLogoutService']['url'])
             ) {
                 $errors[] = 'idp_slo_url_invalid';
             }
@@ -581,13 +581,13 @@ class OneLogin_Saml2_Settings
                 || empty($sp['assertionConsumerService']['url'])
             ) {
                 $errors[] = 'sp_acs_not_found';
-            } else if (!filter_var($sp['assertionConsumerService']['url'], FILTER_VALIDATE_URL)) {
+            } else if (!OneLogin_Saml2_Utils::validateUrl($sp['assertionConsumerService']['url'])) {
                 $errors[] = 'sp_acs_url_invalid';
             }
 
             if (isset($sp['singleLogoutService'])
                 && isset($sp['singleLogoutService']['url'])
-                && !filter_var($sp['singleLogoutService']['url'], FILTER_VALIDATE_URL)
+                && !OneLogin_Saml2_Utils::validateUrl($sp['singleLogoutService']['url'])
             ) {
                 $errors[] = 'sp_sls_url_invalid';
             }

--- a/lib/Saml2/Utils.php
+++ b/lib/Saml2/Utils.php
@@ -1317,4 +1317,25 @@ class OneLogin_Saml2_Utils
             }
         }
     }
+
+    /**
+     * Validates a URL with fallback for URL's that don't comply with RFC 2396
+     *
+     * @param string $url The url we should validate
+     *
+     * @return bool
+     */
+    public static function validateUrl($url)
+    {
+        if (filter_var($url, FILTER_VALIDATE_URL) !== false) {
+            return true;
+        }
+
+        $check = parse_url($url, PHP_URL_HOST);
+        if ($check !== false) {
+            return true;
+        }
+
+        return false;
+    }
 }


### PR DESCRIPTION
The `FILTER_VALIDATE_URL` filter in PHP checks for conformity against [RFC 2396](http://www.faqs.org/rfcs/rfc2396.html). While that seems correct, in the wild there are many URL's that are accepted by browsers that don't conform to RFC 2396 and conform more to [RFC 3986](http://www.faqs.org/rfcs/rfc3986.html). Due to this discrepancy, some "valid" URL's are being marked as invalid by the library even though they work in the wild.

This PR's goal is to still use `FILTER_VALIDATE_URL` to validate URL's but then to do an additional step of validation if `FILTER_VALIDATE_URL` fails.

PHP Bug: https://bugs.php.net/bug.php?id=64948
Stack Overflow question: http://stackoverflow.com/questions/39539468/php-filter-validate-url-not-finding-subdomains-with-underscore
