### PR TITLE
Add support for renaming SAML attributes and filtering attribute values

### DIFF
--- a/.coveralls.yml
+++ b/.coveralls.yml
@@ -1,7 +1,5 @@
 service_name: travis-ci
 
-src_dir: lib
-
 coverage_clover: tests/build/logs/clover.xml
 
 json_path: tests/build/logs/coveralls-upload.json

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,9 @@
 language: php
 
+cache:
+  directories:
+    - $HOME/.composer/cache
+
 php:
   - 5.6
   - 5.5

--- a/lib/Saml2/AttributePolicyHelpers.php
+++ b/lib/Saml2/AttributePolicyHelpers.php
@@ -7,7 +7,8 @@
 
 class OneLogin_Saml2_Settings_AttributePolicyHelpers
 {
-    static function restrictValuesTo($validValues) {
+    static function restrictValuesTo($validValues)
+    {
         return function($values) use ($validValues) {
             $newValues = array();
             foreach ($values as $value) {
@@ -19,7 +20,8 @@ class OneLogin_Saml2_Settings_AttributePolicyHelpers
         };
     }
 
-    static function requireScope($scope) {
+    static function requireScope($scope)
+    {
         $scope = str_replace('.', '\.', $scope);
         return function ($values) use ($scope) {
             $newValues = preg_grep('/^[^@]+@' . $scope . '$/', $values);

--- a/lib/Saml2/AttributePolicyHelpers.php
+++ b/lib/Saml2/AttributePolicyHelpers.php
@@ -1,0 +1,29 @@
+<?php
+
+/**
+ * Attribute Policy helper functions
+ *
+ */
+
+class OneLogin_Saml2_Settings_AttributePolicyHelpers
+{
+    static function restrictValuesTo($validValues) {
+        return function($values) use ($validValues) {
+            $newValues = array();
+            foreach ($values as $value) {
+                if (in_array($value, $validValues, true)) {
+                    array_push($newValues, $value);
+                }
+            }
+            return $newValues;
+        };
+    };
+
+    static function requireScope($scope) {
+        $scope = str_replace('.', '\.', $scope);
+        return function ($values) use ($scope) {
+            $newValues = preg_grep('/^[^@]+@' . $scope . '$/', $values);
+            return $newValues;
+        };
+    }
+}

--- a/lib/Saml2/AttributePolicyHelpers.php
+++ b/lib/Saml2/AttributePolicyHelpers.php
@@ -17,7 +17,7 @@ class OneLogin_Saml2_Settings_AttributePolicyHelpers
             }
             return $newValues;
         };
-    };
+    }
 
     static function requireScope($scope) {
         $scope = str_replace('.', '\.', $scope);

--- a/lib/Saml2/Response.php
+++ b/lib/Saml2/Response.php
@@ -726,54 +726,9 @@ class OneLogin_Saml2_Response
         $spData = $this->_settings->getSPData();
         $attributeMap = $spData['attributeMap'];
         $attributePolicy = $spData['attributePolicy'];
-        $attributes = applyAttributeMapping($attributeMap, $attributes);
-        $attributes = applyAttributePolicy($attributePolicy, $attributes);
+        $attributes = $this->_applyAttributeMapping($attributeMap, $attributes);
+        $attributes = $this->_applyAttributePolicy($attributePolicy, $attributes);
         return $attributes;
-    }
-
-    private function applyAttributeMapping($attributeMap, $attributes)
-    {
-        $mappedAttributes = array();
-
-        foreach ($attributes as $attributeName => $attributeValues) {
-            # Generate hash of new values
-
-            # Default value: identity function
-            $newAttrName = $attributeName;
-            if (array_key_exists($attributeName, $attributeMap)) {
-                # Apply mapping function
-                $newAttrName = $attributeMap[$attributeName];
-            }
-
-            # Merge into already-mapped attribute assoc array
-            # (allows for multiple source attributes to be merged)
-            foreach ($attributeValues as $newAttrValue) {
-                if (!array_key_exists($newAttrName, $mappedAttributes)) {
-                    $mappedAttributes[$newAttrName] = array();
-                }
-                array_push($mappedAttributes[$newAttrName], $newAttrValue);
-            }
-        }
-        return $mappedAttributes;
-    }
-
-    private function applyAttributePolicy($attributePolicy, $attributes)
-    {
-        $filteredAttributes = array();
-
-        foreach ($attributes as $attributeName => $attributeValues) {
-            # Generate hash of new values
-
-            # Default value: identity function
-            $newAttrValues = $attributeValues;
-            if (array_key_exists($attributeName, $attributePolicy)) {
-                # Apply mapping function
-                $newAttrValues = $attributePolicy[$attributeName]($attributeValues);
-            }
-
-            $filteredAttributes[$attributeName] = $newAttrValues;
-        }
-        return $filteredAttributes;
     }
 
     /**
@@ -1120,6 +1075,51 @@ class OneLogin_Saml2_Response
 
             return $decrypted->ownerDocument;
         }
+    }
+
+    protected function _applyAttributeMapping($attributeMap, $attributes)
+    {
+        $mappedAttributes = array();
+
+        foreach ($attributes as $attributeName => $attributeValues) {
+            # Generate hash of new values
+
+            # Default value: identity function
+            $newAttrName = $attributeName;
+            if (array_key_exists($attributeName, $attributeMap)) {
+                # Apply mapping function
+                $newAttrName = $attributeMap[$attributeName];
+            }
+
+            # Merge into already-mapped attribute assoc array
+            # (allows for multiple source attributes to be merged)
+            foreach ($attributeValues as $newAttrValue) {
+                if (!array_key_exists($newAttrName, $mappedAttributes)) {
+                    $mappedAttributes[$newAttrName] = array();
+                }
+                array_push($mappedAttributes[$newAttrName], $newAttrValue);
+            }
+        }
+        return $mappedAttributes;
+    }
+
+    protected function _applyAttributePolicy($attributePolicy, $attributes)
+    {
+        $filteredAttributes = array();
+
+        foreach ($attributes as $attributeName => $attributeValues) {
+            # Generate hash of new values
+
+            # Default value: identity function
+            $newAttrValues = $attributeValues;
+            if (array_key_exists($attributeName, $attributePolicy)) {
+                # Apply mapping function
+                $newAttrValues = $attributePolicy[$attributeName]($attributeValues);
+            }
+
+            $filteredAttributes[$attributeName] = $newAttrValues;
+        }
+        return $filteredAttributes;
     }
 
     /* After execute a validation process, if fails this method returns the cause

--- a/lib/Saml2/Response.php
+++ b/lib/Saml2/Response.php
@@ -1077,6 +1077,14 @@ class OneLogin_Saml2_Response
         }
     }
 
+    /**
+     * Apply attribute name mapping to extracted attributes
+     *
+     * @param array $attributeMap Associative array mapping IdP attribute names to local names
+     * @param array $attributes Associative array of attribute names => values
+     *
+     * @return array Attribute list containing renamed/merged attributes
+     */
     protected function _applyAttributeMapping($attributeMap, $attributes)
     {
         $mappedAttributes = array();
@@ -1103,6 +1111,14 @@ class OneLogin_Saml2_Response
         return $mappedAttributes;
     }
 
+    /**
+     * Filter attribute values
+     *
+     * @param array $attributePolicy Associative array of filter functions per-attribute-name
+     * @param array $attributes Associative array of attribute names => values
+     *
+     * @return array Attribute list containing filtered attribute values
+     */
     protected function _applyAttributePolicy($attributePolicy, $attributes)
     {
         $filteredAttributes = array();

--- a/lib/Saml2/Response.php
+++ b/lib/Saml2/Response.php
@@ -1132,8 +1132,9 @@ class OneLogin_Saml2_Response
                 # Apply mapping function
                 $newAttrValues = $attributePolicy[$attributeName]($attributeValues);
             }
-
-            $filteredAttributes[$attributeName] = $newAttrValues;
+            if (count($newAttrValues) > 0) {
+                $filteredAttributes[$attributeName] = $newAttrValues;
+            }
         }
         return $filteredAttributes;
     }

--- a/lib/Saml2/Response.php
+++ b/lib/Saml2/Response.php
@@ -722,7 +722,56 @@ class OneLogin_Saml2_Response
 
             $attributes[$attributeName] = $attributeValues;
         }
+
+        $spData = $this->_settings->getSPData();
+        $attributeMap = $spData['attributeMap'];
+        $attributePolicy = $spData['attributePolicy'];
+        $attributes = applyAttributeMapping($attributeMap, $attributes);
+        $attributes = applyAttributePolicy($attributePolicy, $attributes);
         return $attributes;
+    }
+
+    private function applyAttributeMapping($attributeMap, $attributes) {
+        $mappedAttributes = array();
+
+        foreach ($attributes as $attributeName => $attributeValues) {
+            # Generate hash of new values
+
+            # Default value: identity function
+            $newAttrName = $attributeName;
+            if (array_key_exists($attributeName, $attributeMap)) {
+                # Apply mapping function
+                $newAttrName = $attributeMap[$attributeName];
+            }
+
+            # Merge into already-mapped attribute assoc array
+            # (allows for multiple source attributes to be merged)
+            foreach ($attributeValues as $newAttrValue) {
+                if (!array_key_exists( $newAttrName, $mappedAttributes)) {
+                    $mappedAttributes[$newAttrName] = array();
+                }
+                array_push($mappedAttributes[$newAttrName], $newAttrValue);
+            }
+        }
+        return $mappedAttributes;
+    }
+
+    private function applyAttributePolicy($attributePolicy, $attributes) {
+        $filteredAttributes = array();
+
+        foreach ($attributes as $attributeName => $attributeValues) {
+            # Generate hash of new values
+
+            # Default value: identity function
+            $newAttrValues = $attributeValues;
+            if (array_key_exists($attributeName, $attributePolicy)) {
+                # Apply mapping function
+                $newAttrValues = $attributePolicy[$attributeName]($attributeValues);
+            }
+
+            $filteredAttributes[$attributeName] = $newAttrValues;
+        }
+        return $filteredAttributes;
     }
 
     /**

--- a/lib/Saml2/Response.php
+++ b/lib/Saml2/Response.php
@@ -731,7 +731,8 @@ class OneLogin_Saml2_Response
         return $attributes;
     }
 
-    private function applyAttributeMapping($attributeMap, $attributes) {
+    private function applyAttributeMapping($attributeMap, $attributes)
+    {
         $mappedAttributes = array();
 
         foreach ($attributes as $attributeName => $attributeValues) {
@@ -747,7 +748,7 @@ class OneLogin_Saml2_Response
             # Merge into already-mapped attribute assoc array
             # (allows for multiple source attributes to be merged)
             foreach ($attributeValues as $newAttrValue) {
-                if (!array_key_exists( $newAttrName, $mappedAttributes)) {
+                if (!array_key_exists($newAttrName, $mappedAttributes)) {
                     $mappedAttributes[$newAttrName] = array();
                 }
                 array_push($mappedAttributes[$newAttrName], $newAttrValue);
@@ -756,7 +757,8 @@ class OneLogin_Saml2_Response
         return $mappedAttributes;
     }
 
-    private function applyAttributePolicy($attributePolicy, $attributes) {
+    private function applyAttributePolicy($attributePolicy, $attributes)
+    {
         $filteredAttributes = array();
 
         foreach ($attributes as $attributeName => $attributeValues) {

--- a/lib/Saml2/Settings.php
+++ b/lib/Saml2/Settings.php
@@ -420,6 +420,12 @@ class OneLogin_Saml2_Settings
         if (!isset($this->_sp['privateKey'])) {
             $this->_sp['privateKey'] = '';
         }
+        if (!isset($this->_sp['attributeMap'])) {
+            $this->_sp['attributeMap'] = array();
+        }
+        if (!isset($this->_sp['attributePolicy'])) {
+            $this->_sp['attributePolicy'] = array();
+        }
     }
 
     /**

--- a/tests/src/OneLogin/Saml2/ResponseTest.php
+++ b/tests/src/OneLogin/Saml2/ResponseTest.php
@@ -1532,7 +1532,7 @@ class OneLogin_Saml2_ResponseTest extends PHPUnit_Framework_TestCase
         $this->assertTrue(!empty($attributes));
         $this->assertEquals('smartin@yaco.es', $attributes['urn:oid:1.3.6.1.7'][0]);
         # Test should fail as-is
-        $this->asserTrue(array_key_exists('mail', $attributes));
+        $this->assertTrue(array_key_exists('mail', $attributes));
     }
 
     public function testAttributePolicy()
@@ -1560,8 +1560,8 @@ class OneLogin_Saml2_ResponseTest extends PHPUnit_Framework_TestCase
         $this->assertTrue($response->isValid());
         $attributes = $response->getAttributes();
         $this->assertTrue(!empty($attributes));
-        $this->assertTrue(in_array('user', $attributes['eduPersonAffiliation']);
+        $this->assertTrue(in_array('user', $attributes['eduPersonAffiliation']));
         # Should break tests...
-        $this->assertTrue(in_array('admin', $attributes['eduPersonAffiliation']);
+        $this->assertTrue(in_array('admin', $attributes['eduPersonAffiliation']));
     }
 }

--- a/tests/src/OneLogin/Saml2/ResponseTest.php
+++ b/tests/src/OneLogin/Saml2/ResponseTest.php
@@ -1542,11 +1542,11 @@ class OneLogin_Saml2_ResponseTest extends PHPUnit_Framework_TestCase
         $settingsInfo['sp']['attributePolicy'] = array(
             'eduPersonAffiliation' => function($values)
             {
-                $valid_values = array('user');
-                $new_values = array();
+                $validValues = array('user');
+                $newValues = array();
                 foreach ($values as $value) {
-                    if (in_array($value, $valid_values, true)) {
-                        array_push($new_values, $value);
+                    if (in_array($value, $validValues, true)) {
+                        array_push($newValues, $value);
                     }
                 }
                 return $new_values;

--- a/tests/src/OneLogin/Saml2/ResponseTest.php
+++ b/tests/src/OneLogin/Saml2/ResponseTest.php
@@ -1597,8 +1597,10 @@ class OneLogin_Saml2_ResponseTest extends PHPUnit_Framework_TestCase
         );
         $settings2 = new OneLogin_Saml2_Settings($settingsInfo2);
         $response2 = new OneLogin_Saml2_Response($settings2, $xml);
-        $this->assertTrue(!empty($attributes));
-        $this->assertFalse(array_key_exists('urn:oid:1.3.6.1.7', $attributes));
+        $this->assertTrue($response2->isValid());
+        $attributes2 = $response2->getAttributes();
+        $this->assertTrue(!empty($attributes2));
+        $this->assertFalse(array_key_exists('urn:oid:1.3.6.1.7', $attributes2));
 
     }
 }

--- a/tests/src/OneLogin/Saml2/ResponseTest.php
+++ b/tests/src/OneLogin/Saml2/ResponseTest.php
@@ -1592,7 +1592,7 @@ class OneLogin_Saml2_ResponseTest extends PHPUnit_Framework_TestCase
 
         $settingsInfo2 = $settingsInfo;
         $settingsInfo2['sp']['attributePolicy'] = array(
-            'eduPersonAffiliation' => $attrHelpers->retrictValuesTo(array('user')),
+            'eduPersonAffiliation' => $attrHelpers->restrictValuesTo(array('user')),
             'urn:oid:1.3.6.1.7' => $attrHelpers->requireScope('yaco.com'), 
         );
         $settings2 = new OneLogin_Saml2_Settings($settingsInfo2);

--- a/tests/src/OneLogin/Saml2/ResponseTest.php
+++ b/tests/src/OneLogin/Saml2/ResponseTest.php
@@ -1549,7 +1549,7 @@ class OneLogin_Saml2_ResponseTest extends PHPUnit_Framework_TestCase
                         array_push($newValues, $value);
                     }
                 }
-                return $new_values;
+                return $newValues;
             },
         );
 

--- a/tests/src/OneLogin/Saml2/ResponseTest.php
+++ b/tests/src/OneLogin/Saml2/ResponseTest.php
@@ -1574,7 +1574,7 @@ class OneLogin_Saml2_ResponseTest extends PHPUnit_Framework_TestCase
             'mail' => 'urn:oid:1.3.6.1.7',
         );
         $settingsInfo['sp']['attributePolicy'] = array(
-            'eduPersonAffiliation' => $attrHelpers->retrictValuesTo(array('user')),
+            'eduPersonAffiliation' => $attrHelpers->restrictValuesTo(array('user')),
             'urn:oid:1.3.6.1.7' => $attrHelpers->requireScope('yaco.es'),
         );
 

--- a/tests/src/OneLogin/Saml2/ResponseTest.php
+++ b/tests/src/OneLogin/Saml2/ResponseTest.php
@@ -1531,8 +1531,7 @@ class OneLogin_Saml2_ResponseTest extends PHPUnit_Framework_TestCase
         $attributes = $response->getAttributes();
         $this->assertTrue(!empty($attributes));
         $this->assertEquals('smartin@yaco.es', $attributes['urn:oid:1.3.6.1.7'][0]);
-        # Test should fail as-is
-        $this->assertTrue(array_key_exists('mail', $attributes));
+        $this->assertFalse(array_key_exists('mail', $attributes));
     }
 
     public function testAttributePolicy()
@@ -1561,7 +1560,6 @@ class OneLogin_Saml2_ResponseTest extends PHPUnit_Framework_TestCase
         $attributes = $response->getAttributes();
         $this->assertTrue(!empty($attributes));
         $this->assertTrue(in_array('user', $attributes['eduPersonAffiliation']));
-        # Should break tests...
-        $this->assertTrue(in_array('admin', $attributes['eduPersonAffiliation']));
+        $this->assertFalse(in_array('admin', $attributes['eduPersonAffiliation']));
     }
 }

--- a/tests/src/OneLogin/Saml2/ResponseTest.php
+++ b/tests/src/OneLogin/Saml2/ResponseTest.php
@@ -1590,7 +1590,7 @@ class OneLogin_Saml2_ResponseTest extends PHPUnit_Framework_TestCase
         $this->assertTrue(in_array('user', $attributes['eduPersonAffiliation']));
         $this->assertFalse(in_array('admin', $attributes['eduPersonAffiliation']));
 
-        $settingsInfo2 = $settingsInfo
+        $settingsInfo2 = $settingsInfo;
         $settingsInfo2['sp']['attributePolicy'] = array(
             'eduPersonAffiliation' => $attrHelpers->retrictValuesTo(array('user')),
             'urn:oid:1.3.6.1.7' => $attrHelpers->requireScope('yaco.com'), 


### PR DESCRIPTION
At present, the php-saml library reports the attribute names in an assertion to the caller as specified by the IdP.  In some cases, applications using the php-saml library expect different attribute names to those in the assertion.  For example, an application may expect to see a "mail" attribute, but the IdP may use the OID form "1.3.6.1.7".  In this case, it is very useful useful to rename or "map" these names to a more friendly form.  It can also be useful to filter out known-bad or unwanted values from the returned attribute values, such as eduPersonScopedAffiliation values with an invalid scope.

This pull request adds two new parameters to the SP configuration block: "attributeMap" and "attributePolicy".  These perform the same basic roles as the similarly attribute-map.xml and attribute-policy.xml files used in the Shibboleth SP software.

The attributeMap parameter is an associative array of 'source'=>'destination' attribute name mappings.  This also supports the merging of many source attributes into a single destination attribute.  If an attribute name is not present as a key, the attribute is passed through as-is.

The attributePolicy parameter is an associative array of filtering functions where the keys are the "destination" attribute names defined in attributeMap.  These take a sole argument of an array of values and return a filtered array of values.  If an attribute name is not present, the values are passed through unfiltered.