### PR TITLE
If the certificate arrays happen to be sparsely indexed this can blow…

### DIFF
--- a/lib/Saml2/Settings.php
+++ b/lib/Saml2/Settings.php
@@ -941,13 +941,13 @@ class OneLogin_Saml2_Settings
     {
         if (isset($this->_idp['x509certMulti'])) {
             if (isset($this->_idp['x509certMulti']['signing'])) {
-                for ($i=0; $i < count($this->_idp['x509certMulti']['signing']); $i++) {
-                    $this->_idp['x509certMulti']['signing'][$i] = OneLogin_Saml2_Utils::formatCert($this->_idp['x509certMulti']['signing'][$i]);
+                foreach($this->_idp['x509certMulti']['signing'] as $i => $cert) {
+                    $this->_idp['x509certMulti']['signing'][$i] = OneLogin_Saml2_Utils::formatCert($cert);
                 }
             }
             if (isset($this->_idp['x509certMulti']['encryption'])) {
-                for ($i=0; $i < count($this->_idp['x509certMulti']['encryption']); $i++) {
-                    $this->_idp['x509certMulti']['encryption'][$i] = OneLogin_Saml2_Utils::formatCert($this->_idp['x509certMulti']['encryption'][$i]);
+                foreach($this->_idp['x509certMulti']['encryption'] as $i => $cert) {
+                    $this->_idp['x509certMulti']['encryption'][$i] = OneLogin_Saml2_Utils::formatCert($cert);
                 }
             }
         }


### PR DESCRIPTION
… out the memory.

One scenario is indexing the certificates based on the short hash, php
will magically expand this hex string in to a very large index number.
eg,
 'd5c242d7' => '-----BEGIN CERTIFICATE-----...'
will cause loop to go from i=0 to i=3586278103