### PR TITLE
Make assertions compatible with PHP 7.2

### DIFF
--- a/lib/Saml2/Auth.php
+++ b/lib/Saml2/Auth.php
@@ -288,8 +288,8 @@ class OneLogin_Saml2_Auth
      */
     public function redirectTo($url = '', $parameters = array(), $stay = false)
     {
-        assert('is_string($url)');
-        assert('is_array($parameters)');
+        assert(is_string($url));
+        assert(is_array($parameters));
 
         if (empty($url) && isset($_REQUEST['RelayState'])) {
             $url = $_REQUEST['RelayState'];
@@ -387,7 +387,7 @@ class OneLogin_Saml2_Auth
      */
     public function getAttribute($name)
     {
-        assert('is_string($name)');
+        assert(is_string($name));
 
         $value = null;
         if (isset($this->_attributes[$name])) {
@@ -410,7 +410,7 @@ class OneLogin_Saml2_Auth
      */
     public function login($returnTo = null, $parameters = array(), $forceAuthn = false, $isPassive = false, $stay = false, $setNameIdPolicy = true)
     {
-        assert('is_array($parameters)');
+        assert(is_array($parameters));
 
         $authnRequest = new OneLogin_Saml2_AuthnRequest($this->_settings, $forceAuthn, $isPassive, $setNameIdPolicy);
 
@@ -451,7 +451,7 @@ class OneLogin_Saml2_Auth
      */
     public function logout($returnTo = null, $parameters = array(), $nameId = null, $sessionIndex = null, $stay = false, $nameIdFormat = null)
     {
-        assert('is_array($parameters)');
+        assert(is_array($parameters));
 
         $sloUrl = $this->getSLOurl();
         if (empty($sloUrl)) {

--- a/lib/Saml2/Error.php
+++ b/lib/Saml2/Error.php
@@ -35,8 +35,8 @@ class OneLogin_Saml2_Error extends Exception
      */
     public function __construct($msg, $code = 0, $args = null)
     {
-        assert('is_string($msg)');
-        assert('is_int($code)');
+        assert(is_string($msg));
+        assert(is_int($code));
 
         $message = OneLogin_Saml2_Utils::t($msg, $args);
 
@@ -111,8 +111,8 @@ class OneLogin_Saml2_ValidationError extends Exception
      */
     public function __construct($msg, $code = 0, $args = null)
     {
-        assert('is_string($msg)');
-        assert('is_int($code)');
+        assert(is_string($msg));
+        assert(is_int($code));
 
         $message = OneLogin_Saml2_Utils::t($msg, $args);
 

--- a/lib/Saml2/Settings.php
+++ b/lib/Saml2/Settings.php
@@ -422,7 +422,7 @@ class OneLogin_Saml2_Settings
      */
     public function checkSettings($settings)
     {
-        assert('is_array($settings)');
+        assert(is_array($settings));
 
         if (!is_array($settings) || empty($settings)) {
             $errors = array('invalid_syntax');
@@ -480,7 +480,7 @@ class OneLogin_Saml2_Settings
      */
     public function checkIdPSettings($settings)
     {
-        assert('is_array($settings)');
+        assert(is_array($settings));
 
         if (!is_array($settings) || empty($settings)) {
             return array('invalid_syntax');
@@ -545,7 +545,7 @@ class OneLogin_Saml2_Settings
      */
     public function checkSPSettings($settings)
     {
-        assert('is_array($settings)');
+        assert(is_array($settings));
 
         if (!is_array($settings) || empty($settings)) {
             return array('invalid_syntax');
@@ -880,7 +880,7 @@ class OneLogin_Saml2_Settings
      */
     public function validateMetadata($xml)
     {
-        assert('is_string($xml)');
+        assert(is_string($xml));
 
         $errors = array();
         $res = OneLogin_Saml2_Utils::validateXML($xml, 'saml-schema-metadata-2.0.xsd', $this->_debug);

--- a/lib/Saml2/Utils.php
+++ b/lib/Saml2/Utils.php
@@ -51,7 +51,8 @@ class OneLogin_Saml2_Utils
      */
     public static function t($msg, $args = array())
     {
-        assert('is_string($msg)');
+        assert(is_string($msg));
+
         if (extension_loaded('gettext')) {
             bindtextdomain("phptoolkit", dirname(dirname(dirname(__FILE__))).'/locale');
             textdomain('phptoolkit');
@@ -80,8 +81,8 @@ class OneLogin_Saml2_Utils
      */
     public static function loadXML($dom, $xml)
     {
-        assert('$dom instanceof DOMDocument');
-        assert('is_string($xml)');
+        assert($dom instanceof DOMDocument);
+        assert(is_string($xml));
 
         if (strpos($xml, '<!ENTITY') !== false) {
             throw new Exception('Detected use of ENTITY in XML, disabled to prevent XXE/XEE attacks');
@@ -111,8 +112,8 @@ class OneLogin_Saml2_Utils
      */
     public static function validateXML($xml, $schema, $debug = false)
     {
-        assert('is_string($xml) || $xml instanceof DOMDocument');
-        assert('is_string($schema)');
+        assert(is_string($xml) || $xml instanceof DOMDocument);
+        assert(is_string($schema));
 
         libxml_clear_errors();
         libxml_use_internal_errors(true);
@@ -248,8 +249,8 @@ class OneLogin_Saml2_Utils
      */
     public static function redirect($url, $parameters = array(), $stay = false)
     {
-        assert('is_string($url)');
-        assert('is_array($parameters)');
+        assert(is_string($url));
+        assert(is_array($parameters));
 
         if (substr($url, 0, 1) === '/') {
             $url = self::getSelfURLhost() . $url;
@@ -263,7 +264,7 @@ class OneLogin_Saml2_Utils
             );
         }
 
-        
+
         /* Add encoded parameters */
         if (strpos($url, '?') === false) {
             $paramPrefix = '?';
@@ -726,8 +727,8 @@ class OneLogin_Saml2_Utils
      */
     public static function parseDuration($duration, $timestamp = null)
     {
-        assert('is_string($duration)');
-        assert('is_null($timestamp) || is_int($timestamp)');
+        assert(is_string($duration));
+        assert(is_null($timestamp) || is_int($timestamp));
 
         /* Parse the duration. We use a very strict pattern. */
         $durationRegEx = '#^(-?)P(?:(?:(?:(\\d+)Y)?(?:(\\d+)M)?(?:(\\d+)D)?(?:T(?:(\\d+)H)?(?:(\\d+)M)?(?:(\\d+)S)?)?)|(?:(\\d+)W))$#D';
@@ -894,7 +895,7 @@ class OneLogin_Saml2_Utils
      */
     public static function calculateX509Fingerprint($x509cert, $alg = 'sha1')
     {
-        assert('is_string($x509cert)');
+        assert(is_string($x509cert));
 
         $lines = explode("\n", $x509cert);
 
@@ -1150,7 +1151,7 @@ class OneLogin_Saml2_Utils
                 OneLogin_Saml2_ValidationError::INVALID_XML_FORMAT
             );
         }
- 
+
         $decryptedElement = $newDoc->firstChild->firstChild;
         if ($decryptedElement === null) {
             throw new OneLogin_Saml2_ValidationError(
@@ -1175,8 +1176,9 @@ class OneLogin_Saml2_Utils
       */
     public static function castKey(XMLSecurityKey $key, $algorithm, $type = 'public')
     {
-        assert('is_string($algorithm)');
-        assert('$type === "public" || $type === "private"');
+        assert(is_string($algorithm));
+        assert($type === 'public' || $type === 'private');
+
         // do nothing if algorithm is already the type of the key
         if ($key->type === $algorithm) {
             return $key;


### PR DESCRIPTION
[Using string as the assertion is deprecated as of PHP 7.2](http://php.net/assert#refsect1-function.assert-parameters). Depending on the PHP version, the library will use either strings, or expressions.