### PR TITLE
fix(composer): Exclude test files from Composer production downloads

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,4 +1,9 @@
-/.gitattributes export-ignore
 /.coveralls.yml export-ignore
+/.gitattributes export-ignore
+/.gitignore export-ignore
 /.travis.yml export-ignore
+/demo-old export-ignore
+/demo1 export-ignore
+/demo2 export-ignore
+/phpdoc.xml export-ignore
 /tests export-ignore

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,4 @@
+/.gitattributes export-ignore
+/.coveralls.yml export-ignore
+/.travis.yml export-ignore
+/tests export-ignore


### PR DESCRIPTION
Test code should not end up in a production deployment for security reasons. Please exclude test code from Composer downloads. This can be done with https://blog.madewithlove.be/post/gitattributes/

Not sure if you also want to exclude other stuff like README and example files?