### PR TITLE
Refactors Utils::getSelfPort() to detect port correctly when using port forwarding

### DIFF
--- a/lib/Saml2/Utils.php
+++ b/lib/Saml2/Utils.php
@@ -514,14 +514,13 @@ class OneLogin_Saml2_Utils
         $currentHost = self::getRawHost();
 
         // strip the port
-        if (false !== strpos($currentHost, ':')) {
-            list($currentHost, $port) = explode(':', $currentHost, 2);
-            if (is_numeric($port)) {
-                return $port;
-            }
+        if (false === strpos($currentHost, ':')) {
+            return null;
         }
 
-        return null;
+        list($currentHost, $port) = explode(':', $currentHost, 2);
+
+        return is_numeric($port) ? $port : null;
     }
 
     /**

--- a/lib/Saml2/Utils.php
+++ b/lib/Saml2/Utils.php
@@ -491,25 +491,37 @@ class OneLogin_Saml2_Utils
      */
     public static function getSelfPort()
     {
-        $portnumber = null;
         if (self::$_port) {
-            $portnumber = self::$_port;
-        } else if (self::getProxyVars() && isset($_SERVER["HTTP_X_FORWARDED_PORT"])) {
-            $portnumber = $_SERVER["HTTP_X_FORWARDED_PORT"];
-        } else if (isset($_SERVER["SERVER_PORT"])) {
-            $portnumber = $_SERVER["SERVER_PORT"];
-        } else {
-            $currentHost = self::getRawHost();
+            return self::$_port;
+        }
 
-            // strip the port
-            if (false !== strpos($currentHost, ':')) {
-                list($currentHost, $port) = explode(':', $currentHost, 2);
-                if (is_numeric($port)) {
-                    $portnumber = $port;
-                }
+        if (self::getProxyVars() && isset($_SERVER["HTTP_X_FORWARDED_PORT"])) {
+            return $_SERVER["HTTP_X_FORWARDED_PORT"];
+        }
+
+        if (isset($_SERVER["SERVER_PORT"]) && $_SERVER["SERVER_PORT"] == self::getSelfPortFromSelfRawHost()) {
+            return $_SERVER["SERVER_PORT"];
+        }
+
+        return self::getSelfPortFromSelfRawHost();
+    }
+
+    /**
+     * @return int|string|null
+     */
+    private static function getSelfPortFromSelfRawHost()
+    {
+        $currentHost = self::getRawHost();
+
+        // strip the port
+        if (false !== strpos($currentHost, ':')) {
+            list($currentHost, $port) = explode(':', $currentHost, 2);
+            if (is_numeric($port)) {
+                return $port;
             }
         }
-        return $portnumber;
+
+        return null;
     }
 
     /**

--- a/tests/src/OneLogin/Saml2/UtilsTest.php
+++ b/tests/src/OneLogin/Saml2/UtilsTest.php
@@ -406,15 +406,19 @@ class OneLogin_Saml2_UtilsTest extends PHPUnit_Framework_TestCase
         unset($_SERVER['SERVER_PORT']);
         unset($_SERVER['HTTP_X_FORWARDED_PORT']);
 
+        $_SERVER["HTTP_X_FORWARDED_PORT"] = 443;
         OneLogin_Saml2_Utils::setProxyVars(true);
         $this->assertEquals(443, OneLogin_Saml2_Utils::getSelfPort());
+        unset($_SERVER['HTTP_X_FORWARDED_PORT']);
+        OneLogin_Saml2_Utils::setProxyVars(false);
 
         OneLogin_Saml2_Utils::setSelfPort(8080);
         $this->assertEquals(8080, OneLogin_Saml2_Utils::getSelfPort());
+        OneLogin_Saml2_Utils::setSelfPort(null);
 
         $_SERVER["SERVER_PORT"] = 443;
         $_SERVER["HTTP_HOST"] = 'example.org:44300';
-        $this->assertEquals(443, OneLogin_Saml2_Utils::getSelfPort());
+        $this->assertEquals(44300, OneLogin_Saml2_Utils::getSelfPort());
         unset($_SERVER["SERVER_PORT"]);
         unset($_SERVER["HTTP_HOST"]);
     }
@@ -512,9 +516,11 @@ class OneLogin_Saml2_UtilsTest extends PHPUnit_Framework_TestCase
         $_SERVER['SERVER_PORT'] = '80';
         $this->assertEquals("http://$hostname", OneLogin_Saml2_Utils::getSelfURLhost());
 
+        $_SERVER['HTTP_HOST'] = $hostname . ':81';
         $_SERVER['SERVER_PORT'] = '81';
         $this->assertEquals("http://$hostname:81", OneLogin_Saml2_Utils::getSelfURLhost());
 
+        $_SERVER['HTTP_HOST'] = $hostname . ':443';
         $_SERVER['SERVER_PORT'] = '443';
         $this->assertEquals("https://$hostname", OneLogin_Saml2_Utils::getSelfURLhost());
 
@@ -522,9 +528,11 @@ class OneLogin_Saml2_UtilsTest extends PHPUnit_Framework_TestCase
         $_SERVER['HTTPS'] = 'on';
         $this->assertEquals("https://$hostname", OneLogin_Saml2_Utils::getSelfURLhost());
 
+        $_SERVER['HTTP_HOST'] = $hostname . ':444';
         $_SERVER['SERVER_PORT'] = '444';
         $this->assertEquals("https://$hostname:444", OneLogin_Saml2_Utils::getSelfURLhost());
 
+        $_SERVER['HTTP_HOST'] = $hostname . ':443';
         $_SERVER['SERVER_PORT'] = '443';
         $_SERVER['REQUEST_URI'] = '/onelogin';
         $this->assertEquals("https://$hostname", OneLogin_Saml2_Utils::getSelfURLhost());

--- a/tests/src/OneLogin/Saml2/UtilsTest.php
+++ b/tests/src/OneLogin/Saml2/UtilsTest.php
@@ -385,21 +385,38 @@ class OneLogin_Saml2_UtilsTest extends PHPUnit_Framework_TestCase
 
         $_SERVER['HTTP_HOST'] = 'example.org:ok';
         $this->assertNull(OneLogin_Saml2_Utils::getSelfPort());
+        unset($_SERVER['HTTP_HOST']);
 
         $_SERVER['HTTP_HOST'] = 'example.org:8080';
         $this->assertEquals(8080, OneLogin_Saml2_Utils::getSelfPort());
+        unset($_SERVER['HTTP_HOST']);
 
+        $_SERVER['HTTP_HOST'] = 'example.org:80';
         $_SERVER["SERVER_PORT"] = 80;
         $this->assertEquals(80, OneLogin_Saml2_Utils::getSelfPort());
+        unset($_SERVER['HTTP_HOST']);
+        unset($_SERVER['SERVER_PORT']);
 
+        $_SERVER["SERVER_PORT"] = 80;
+        $_SERVER['HTTP_HOST'] = 'example.org:80';
         $_SERVER["HTTP_X_FORWARDED_PORT"] = 443;
+        OneLogin_Saml2_Utils::setProxyVars(false);
         $this->assertEquals(80, OneLogin_Saml2_Utils::getSelfPort());
+        unset($_SERVER['HTTP_HOST']);
+        unset($_SERVER['SERVER_PORT']);
+        unset($_SERVER['HTTP_X_FORWARDED_PORT']);
 
         OneLogin_Saml2_Utils::setProxyVars(true);
         $this->assertEquals(443, OneLogin_Saml2_Utils::getSelfPort());
 
         OneLogin_Saml2_Utils::setSelfPort(8080);
         $this->assertEquals(8080, OneLogin_Saml2_Utils::getSelfPort());
+
+        $_SERVER["SERVER_PORT"] = 443;
+        $_SERVER["HTTP_HOST"] = 'example.org:44300';
+        $this->assertEquals(443, OneLogin_Saml2_Utils::getSelfPort());
+        unset($_SERVER["SERVER_PORT"]);
+        unset($_SERVER["HTTP_HOST"]);
     }
 
     /**


### PR DESCRIPTION
As per #238 

The tests for getSelfPort() all pass but I had problems with some other tests (which wouldn't pass even before I made any changes).

I had to make some changes to the test method in order to get all test cases to pass, i.e. being explicit about which `$_SERVER` values were being set for each test. IMO this test method could do with being split into several methods, one per test case.