### PR TITLE
Document that SHA-1 must not be used

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,8 +152,10 @@ start, for example to use the static method getSelfURLNoQuery use:
 Security warning
 ----------------
 
-In production, the `strict` parameter **MUST** be set as `"true"`. Otherwise
-your environment is not secure and will be exposed to attacks.
+In production, the `strict` parameter **MUST** be set as `"true"` and the
+`signatureAlgorithm` and `digestAlgorithm` under `security` must be set to
+something other than SHA1 (see https://shattered.io/ ). Otherwise your
+environment is not secure and will be exposed to attacks.
 
 
 Getting started

--- a/README.md
+++ b/README.md
@@ -276,6 +276,25 @@ file, rename and edit it.
 <?php
 
 $settings = array (
+    // Security settings that must be set to avoid insecure SHA-1 usage.
+    'security' => array (
+        // Algorithm that the toolkit will use on signing process. Options:
+        //    'http://www.w3.org/2001/04/xmldsig-more#rsa-sha256'
+        //    'http://www.w3.org/2001/04/xmldsig-more#rsa-sha384'
+        //    'http://www.w3.org/2001/04/xmldsig-more#rsa-sha512'
+        // Insecure options that must not be used (still available for backwards compatibility):
+        //    'http://www.w3.org/2000/09/xmldsig#rsa-sha1'
+        //    'http://www.w3.org/2000/09/xmldsig#dsa-sha1'
+        'signatureAlgorithm' => 'http://www.w3.org/2001/04/xmldsig-more#rsa-sha256',
+
+        // Algorithm that the toolkit will use on digest process. Options:
+        //    'http://www.w3.org/2001/04/xmlenc#sha256'
+        //    'http://www.w3.org/2001/04/xmldsig-more#sha384'
+        //    'http://www.w3.org/2001/04/xmlenc#sha512'
+        // Insecure options that must not be used (still available for backwards compatibility):
+        //    'http://www.w3.org/2000/09/xmldsig#sha1'
+        'digestAlgorithm' => 'http://www.w3.org/2001/04/xmlenc#sha256',
+    ),
     // If 'strict' is True, then the PHP Toolkit will reject unsigned
     // or unencrypted messages if it expects them to be signed or encrypted.
     // Also it will reject the messages if the SAML standard is not strictly
@@ -383,13 +402,14 @@ $settings = array (
          *
          *  If a fingerprint is provided, then the certFingerprintAlgorithm is required in order to
          *  let the toolkit know which algorithm was used. Possible values: sha1, sha256, sha384 or sha512
-         *  'sha1' is the default value.
+         *  'sha1' is the default value for compatibilty reasons but must not be
+         *  used for security reasons.
          *
          *  Notice that if you want to validate any SAML Message sent by the HTTP-Redirect binding, you
          *  will need to provide the whole x509cert.
          */
         // 'certFingerprint' => '',
-        // 'certFingerprintAlgorithm' => 'sha1',
+        // 'certFingerprintAlgorithm' => 'sha256',
 
         /* In some scenarios the IdP uses different certificates for
          * signing/encryption, or is under key rollover phase and
@@ -491,19 +511,21 @@ $advancedSettings = array (
         'relaxDestinationValidation' => false,
 
         // Algorithm that the toolkit will use on signing process. Options:
-        //    'http://www.w3.org/2000/09/xmldsig#rsa-sha1'
-        //    'http://www.w3.org/2000/09/xmldsig#dsa-sha1'
         //    'http://www.w3.org/2001/04/xmldsig-more#rsa-sha256'
         //    'http://www.w3.org/2001/04/xmldsig-more#rsa-sha384'
         //    'http://www.w3.org/2001/04/xmldsig-more#rsa-sha512'
-        'signatureAlgorithm' => 'http://www.w3.org/2000/09/xmldsig#rsa-sha1',
+        // Insecure options that must not be used (still available for backwards compatibility):
+        //    'http://www.w3.org/2000/09/xmldsig#rsa-sha1'
+        //    'http://www.w3.org/2000/09/xmldsig#dsa-sha1'
+        'signatureAlgorithm' => 'http://www.w3.org/2001/04/xmldsig-more#rsa-sha256',
 
         // Algorithm that the toolkit will use on digest process. Options:
-        //    'http://www.w3.org/2000/09/xmldsig#sha1'
         //    'http://www.w3.org/2001/04/xmlenc#sha256'
         //    'http://www.w3.org/2001/04/xmldsig-more#sha384'
         //    'http://www.w3.org/2001/04/xmlenc#sha512'
-        'digestAlgorithm' => 'http://www.w3.org/2000/09/xmldsig#sha1',
+        // Insecure options that must not be used (still available for backwards compatibility):
+        //    'http://www.w3.org/2000/09/xmldsig#sha1'
+        'digestAlgorithm' => 'http://www.w3.org/2001/04/xmlenc#sha256',
 
         // ADFS URL-Encodes SAML data as lowercase, and the toolkit by default uses
         // uppercase. Turn it True for ADFS compatibility on signature verification

--- a/advanced_settings_example.php
+++ b/advanced_settings_example.php
@@ -82,19 +82,21 @@ $advancedSettings = array (
         'relaxDestinationValidation' => false,
 
         // Algorithm that the toolkit will use on signing process. Options:
-        //    'http://www.w3.org/2000/09/xmldsig#rsa-sha1'
-        //    'http://www.w3.org/2000/09/xmldsig#dsa-sha1'
         //    'http://www.w3.org/2001/04/xmldsig-more#rsa-sha256'
         //    'http://www.w3.org/2001/04/xmldsig-more#rsa-sha384'
         //    'http://www.w3.org/2001/04/xmldsig-more#rsa-sha512'
-        'signatureAlgorithm' => 'http://www.w3.org/2000/09/xmldsig#rsa-sha1',
+        // Insecure options that must not be used (still available for backwards compatibility):
+        //    'http://www.w3.org/2000/09/xmldsig#rsa-sha1'
+        //    'http://www.w3.org/2000/09/xmldsig#dsa-sha1'
+        'signatureAlgorithm' => 'http://www.w3.org/2001/04/xmldsig-more#rsa-sha256',
 
         // Algorithm that the toolkit will use on digest process. Options:
-        //    'http://www.w3.org/2000/09/xmldsig#sha1'
         //    'http://www.w3.org/2001/04/xmlenc#sha256'
         //    'http://www.w3.org/2001/04/xmldsig-more#sha384'
         //    'http://www.w3.org/2001/04/xmlenc#sha512'
-        'digestAlgorithm' => 'http://www.w3.org/2000/09/xmldsig#sha1',
+        // Insecure options that must not be used (still available for backwards compatibility):
+        //    'http://www.w3.org/2000/09/xmldsig#sha1'
+        'digestAlgorithm' => 'http://www.w3.org/2001/04/xmlenc#sha256',
 
         // ADFS URL-Encodes SAML data as lowercase, and the toolkit by default uses
         // uppercase. Turn it True for ADFS compatibility on signature verification

--- a/settings_example.php
+++ b/settings_example.php
@@ -1,6 +1,25 @@
 <?php
 
 $settings = array (
+    // Security settings that must be set to avoid insecure SHA-1 usage.
+    'security' => array (
+        // Algorithm that the toolkit will use on signing process. Options:
+        //    'http://www.w3.org/2001/04/xmldsig-more#rsa-sha256'
+        //    'http://www.w3.org/2001/04/xmldsig-more#rsa-sha384'
+        //    'http://www.w3.org/2001/04/xmldsig-more#rsa-sha512'
+        // Insecure options that must not be used (still available for backwards compatibility):
+        //    'http://www.w3.org/2000/09/xmldsig#rsa-sha1'
+        //    'http://www.w3.org/2000/09/xmldsig#dsa-sha1'
+        'signatureAlgorithm' => 'http://www.w3.org/2001/04/xmldsig-more#rsa-sha256',
+
+        // Algorithm that the toolkit will use on digest process. Options:
+        //    'http://www.w3.org/2001/04/xmlenc#sha256'
+        //    'http://www.w3.org/2001/04/xmldsig-more#sha384'
+        //    'http://www.w3.org/2001/04/xmlenc#sha512'
+        // Insecure options that must not be used (still available for backwards compatibility):
+        //    'http://www.w3.org/2000/09/xmldsig#sha1'
+        'digestAlgorithm' => 'http://www.w3.org/2001/04/xmlenc#sha256',
+    ),
     // If 'strict' is True, then the PHP Toolkit will reject unsigned
     // or unencrypted messages if it expects them signed or encrypted
     // Also will reject the messages if not strictly follow the SAML
@@ -106,11 +125,15 @@ $settings = array (
          *   or add for example the -sha256 , -sha384 or -sha512 parameter)
          *
          *  If a fingerprint is provided, then the certFingerprintAlgorithm is required in order to
-         *  let the toolkit know which Algorithm was used. Possible values: sha1, sha256, sha384 or sha512
-         *  'sha1' is the default value.
+         *  let the toolkit know which algorithm was used. Possible values: sha1, sha256, sha384 or sha512
+         *  'sha1' is the default value for compatibilty reasons but must not be
+         *  used for security reasons.
+         *
+         *  Notice that if you want to validate any SAML Message sent by the HTTP-Redirect binding, you
+         *  will need to provide the whole x509cert.
          */
         // 'certFingerprint' => '',
-        // 'certFingerprintAlgorithm' => 'sha1',
+        // 'certFingerprintAlgorithm' => 'sha256',
 
         /* In some scenarios the IdP uses different certificates for
          * signing/encryption, or is under key rollover phase and more 

--- a/settings_example.php
+++ b/settings_example.php
@@ -125,15 +125,11 @@ $settings = array (
          *   or add for example the -sha256 , -sha384 or -sha512 parameter)
          *
          *  If a fingerprint is provided, then the certFingerprintAlgorithm is required in order to
-         *  let the toolkit know which algorithm was used. Possible values: sha1, sha256, sha384 or sha512
-         *  'sha1' is the default value for compatibilty reasons but must not be
-         *  used for security reasons.
-         *
-         *  Notice that if you want to validate any SAML Message sent by the HTTP-Redirect binding, you
-         *  will need to provide the whole x509cert.
+         *  let the toolkit know which Algorithm was used. Possible values: sha1, sha256, sha384 or sha512
+         *  'sha1' is the default value.
          */
         // 'certFingerprint' => '',
-        // 'certFingerprintAlgorithm' => 'sha256',
+        // 'certFingerprintAlgorithm' => 'sha1',
 
         /* In some scenarios the IdP uses different certificates for
          * signing/encryption, or is under key rollover phase and more 


### PR DESCRIPTION
Follow-up to #237 . We cannot change SHA1 as default value in the 2.x version of this library, but we can at least warn new users to use the correct settings.