### PR TITLE
Expose attributes with FriendlyName aswell as Name

### DIFF
--- a/lib/Saml2/Response.php
+++ b/lib/Saml2/Response.php
@@ -725,24 +725,26 @@ class OneLogin_Saml2_Response
 
         /** @var $entry DOMNode */
         foreach ($entries as $entry) {
-            $attributeName = $entry->attributes->getNamedItem('Name')->nodeValue;
+			foreach(array('Name', 'FriendlyName') as $fieldName) {
+				$attributeName = $entry->attributes->getNamedItem($fieldName)->nodeValue;
 
-            if (in_array($attributeName, array_keys($attributes))) {
-                throw new OneLogin_Saml2_ValidationError(
-                    "Found an Attribute element with duplicated Name",
-                    OneLogin_Saml2_ValidationError::DUPLICATED_ATTRIBUTE_NAME_FOUND
-                );
-            }
+				if (in_array($attributeName, array_keys($attributes))) {
+					throw new OneLogin_Saml2_ValidationError(
+						"Found an Attribute element with duplicated Name",
+						OneLogin_Saml2_ValidationError::DUPLICATED_ATTRIBUTE_NAME_FOUND
+					);
+				}
 
-            $attributeValues = array();
-            foreach ($entry->childNodes as $childNode) {
-                $tagName = ($childNode->prefix ? $childNode->prefix.':' : '') . 'AttributeValue';
-                if ($childNode->nodeType == XML_ELEMENT_NODE && $childNode->tagName === $tagName) {
-                    $attributeValues[] = $childNode->nodeValue;
-                }
-            }
+				$attributeValues = array();
+				foreach ($entry->childNodes as $childNode) {
+					$tagName = ($childNode->prefix ? $childNode->prefix.':' : '') . 'AttributeValue';
+					if ($childNode->nodeType == XML_ELEMENT_NODE && $childNode->tagName === $tagName) {
+						$attributeValues[] = $childNode->nodeValue;
+					}
+				}
 
-            $attributes[$attributeName] = $attributeValues;
+				$attributes[$attributeName] = $attributeValues;
+			}
         }
         return $attributes;
     }


### PR DESCRIPTION
Attribute FriendlyNames (telephoneNumber) are much easier to use compared to Names (urn:oid:2.5.4.20). It removes the need to manually map attributes in your application.  Tested with Shibboleth https://wiki.shibboleth.net/confluence/display/SHIB2/AttributeNaming