### PR TITLE
SAML 2.0 spec allows for zero SubjectConfirmation nodes

### DIFF
--- a/lib/Saml2/Response.php
+++ b/lib/Saml2/Response.php
@@ -285,7 +285,7 @@ class OneLogin_Saml2_Response
                 }
 
                 // Check the SubjectConfirmation, at least one SubjectConfirmation must be valid
-                $anySubjectConfirmation = false;
+                $validSubjectConfirmation = false;
                 $subjectConfirmationNodes = $this->_queryAssertion('/saml:Subject/saml:SubjectConfirmation');
                 foreach ($subjectConfirmationNodes as $scn) {
                     if ($scn->hasAttribute('Method') && $scn->getAttribute('Method') != OneLogin_Saml2_Constants::CM_BEARER) {
@@ -325,12 +325,12 @@ class OneLogin_Saml2_Response
                         if ($scnData->hasAttribute('NotOnOrAfter')) {
                             $this->_validSCDNotOnOrAfter = $noa;
                         }
-                        $anySubjectConfirmation = true;
+                        $validSubjectConfirmation = true;
                         break;
                     }
                 }
 
-                if (!$anySubjectConfirmation) {
+                if (!$validSubjectConfirmation) {
                     throw new OneLogin_Saml2_ValidationError(
                         "A valid SubjectConfirmation was not found on this Response",
                         OneLogin_Saml2_ValidationError::WRONG_SUBJECTCONFIRMATION

--- a/lib/Saml2/Response.php
+++ b/lib/Saml2/Response.php
@@ -287,6 +287,12 @@ class OneLogin_Saml2_Response
                 // Check the SubjectConfirmation, at least one SubjectConfirmation must be valid
                 $validSubjectConfirmation = false;
                 $subjectConfirmationNodes = $this->_queryAssertion('/saml:Subject/saml:SubjectConfirmation');
+
+                // Zero nodes are also acceptable according to SAML 2.0 spec
+                if (count($subjectConfirmationNodes) == 0) {
+                    $validSubjectConfirmation = true;
+                }
+
                 foreach ($subjectConfirmationNodes as $scn) {
                     if ($scn->hasAttribute('Method') && $scn->getAttribute('Method') != OneLogin_Saml2_Constants::CM_BEARER) {
                         continue;


### PR DESCRIPTION
In the spec, it reads like a Subject declaration can have zero SubjectConfirmation nodes:

> 
> <SubjectConfirmation> [Zero or More]
> A <Subject> element can contain both an identifier and zero or more subject confirmations which a relying party can verify when processing an assertion.
> ...
> If there are no subject confirmations included, then any relationship between the presenter of the assertion and the actual subject is unspecified.

This PR would make it so that the lack of a SubjectConfirmation would not throw a `A valid SubjectConfirmation was not found on this Response` Exception. 