### PR TITLE
Escape error messages in debug mode

### DIFF
--- a/lib/Saml2/LogoutRequest.php
+++ b/lib/Saml2/LogoutRequest.php
@@ -380,7 +380,7 @@ LOGOUTREQUEST;
             $this->_error = $e->getMessage();
             $debug = $this->_settings->isDebugActive();
             if ($debug) {
-                echo $this->_error;
+                echo htmlentities($this->_error);
             }
             return false;
         }

--- a/lib/Saml2/LogoutResponse.php
+++ b/lib/Saml2/LogoutResponse.php
@@ -188,7 +188,7 @@ class OneLogin_Saml2_LogoutResponse
             $this->_error = $e->getMessage();
             $debug = $this->_settings->isDebugActive();
             if ($debug) {
-                echo $this->_error;
+                echo htmlentities($this->_error);
             }
             return false;
         }

--- a/lib/Saml2/Response.php
+++ b/lib/Saml2/Response.php
@@ -402,7 +402,7 @@ class OneLogin_Saml2_Response
             $this->_error = $e->getMessage();
             $debug = $this->_settings->isDebugActive();
             if ($debug) {
-                echo $this->_error;
+                echo htmlentities($this->_error);
             }
             return false;
         }

--- a/lib/Saml2/Utils.php
+++ b/lib/Saml2/Utils.php
@@ -134,7 +134,7 @@ class OneLogin_Saml2_Utils
 
             if ($debug) {
                 foreach ($xmlErrors as $error) {
-                    echo $error->message."\n";
+                    echo htmlentities($error->message."\n");
                 }
             }
 


### PR DESCRIPTION
While one could argue that turning on debug mode is itself something you shouldn't do in production at least for some providers this seems to be the case.

Signed-off-by: Lukas Reschke <lukas@statuscode.ch>