### PR TITLE
Fix PHPDocs and correct invalid throw exceptions

### DIFF
--- a/lib/Saml2/Auth.php
+++ b/lib/Saml2/Auth.php
@@ -98,7 +98,7 @@ class OneLogin_Saml2_Auth
     /**
      * Reason of the last error.
      *
-     * @var string
+     * @var string|null
      */
     private $_errorReason;
 
@@ -387,7 +387,7 @@ class OneLogin_Saml2_Auth
     /**
      * Returns the reason for the last error
      *
-     * @return string  Error reason
+     * @return string|null Error reason
      */
     public function getLastErrorReason()
     {

--- a/lib/Saml2/Auth.php
+++ b/lib/Saml2/Auth.php
@@ -677,7 +677,7 @@ class OneLogin_Saml2_Auth
      * If the SAMLResponse was encrypted, by default tries
      * to return the decrypted XML.
      *
-     * @return string The Response XML
+     * @return string|null The Response XML
      */
     public function getLastResponseXML()
     {

--- a/lib/Saml2/Auth.php
+++ b/lib/Saml2/Auth.php
@@ -84,7 +84,7 @@ class OneLogin_Saml2_Auth
      * The NotOnOrAfter value of the valid SubjectConfirmationData
      * node (if any) of the last assertion processed
      *
-     * @var DateTime
+     * @var int
      */
     private $_lastAssertionNotOnOrAfter;
 
@@ -651,7 +651,7 @@ class OneLogin_Saml2_Auth
     }
 
     /**
-     * @return The NotOnOrAfter value of the valid
+     * @return int The NotOnOrAfter value of the valid
      *         SubjectConfirmationData node (if any)
      *         of the last assertion processed
      */

--- a/lib/Saml2/Auth.php
+++ b/lib/Saml2/Auth.php
@@ -291,6 +291,7 @@ class OneLogin_Saml2_Auth
      * @param string $url        The target URL to redirect the user.
      * @param array  $parameters Extra parameters to be passed as part of the url
      * @param bool   $stay       True if we want to stay (returns the url string) False to redirect
+     * @return string|null
      */
     public function redirectTo($url = '', $parameters = array(), $stay = false)
     {
@@ -422,7 +423,7 @@ class OneLogin_Saml2_Auth
      * @param bool        $stay            True if we want to stay (returns the url string) False to redirect
      * @param bool        $setNameIdPolicy When true the AuthNReuqest will set a nameIdPolicy element
      *
-     * @return If $stay is True, it return a string with the SLO URL + LogoutRequest + parameters
+     * @return string|null If $stay is True, it return a string with the SLO URL + LogoutRequest + parameters
      */
     public function login($returnTo = null, $parameters = array(), $forceAuthn = false, $isPassive = false, $stay = false, $setNameIdPolicy = true)
     {
@@ -462,7 +463,7 @@ class OneLogin_Saml2_Auth
      * @param string|null $nameIdFormat        The NameID Format will be set in the LogoutRequest.
      * @param string|null $nameIdNameQualifier The NameID NameQualifier will be set in the LogoutRequest.
      *
-     * @return If $stay is True, it return a string with the SLO URL + LogoutRequest + parameters
+     * @return string|null If $stay is True, it return a string with the SLO URL + LogoutRequest + parameters
      *
      * @throws OneLogin_Saml2_Error
      */

--- a/lib/Saml2/Auth.php
+++ b/lib/Saml2/Auth.php
@@ -62,7 +62,7 @@ class OneLogin_Saml2_Auth
      * SessionNotOnOrAfter. When the user is logged, this stored it
      * from the AuthnStatement of the SAML Response
      *
-     * @var DateTime
+     * @var int|null
      */
     private $_sessionExpiration;
 

--- a/lib/Saml2/Auth.php
+++ b/lib/Saml2/Auth.php
@@ -150,8 +150,7 @@ class OneLogin_Saml2_Auth
      * Set the strict mode active/disable
      *
      * @param bool $value Strict parameter
-     *
-     * @return array The settings data.
+     * @throws OneLogin_Saml2_Error
      */
     public function setStrict($value)
     {

--- a/lib/Saml2/IdPMetadataParser.php
+++ b/lib/Saml2/IdPMetadataParser.php
@@ -189,8 +189,8 @@ class OneLogin_Saml2_IdPMetadataParser
     /**
      * Inject metadata info into php-saml settings array
      *
-     * @param string $settings      php-saml settings array
-     * @param string $metadataInfo  array metadata info
+     * @param array $settings      php-saml settings array
+     * @param array $metadataInfo  array metadata info
      *
      * @return array settings
      */

--- a/lib/Saml2/IdPMetadataParser.php
+++ b/lib/Saml2/IdPMetadataParser.php
@@ -144,13 +144,11 @@ class OneLogin_Saml2_IdPMetadataParser
                 if (!empty($keyDescriptorCertSigningNodes) || !empty($keyDescriptorCertEncryptionNodes)) {
                     $metadataInfo['idp']['x509certMulti'] = array();
                     if (!empty($keyDescriptorCertSigningNodes)) {
-                        $idpInfo['x509certMulti']['signing'] = array();
                         foreach ($keyDescriptorCertSigningNodes as $keyDescriptorCertSigningNode) {
                             $metadataInfo['idp']['x509certMulti']['signing'][] = OneLogin_Saml2_Utils::formatCert($keyDescriptorCertSigningNode->nodeValue, false);
                         }
                     }
                     if (!empty($keyDescriptorCertEncryptionNodes)) {
-                        $idpInfo['x509certMulti']['encryption'] = array();
                         foreach ($keyDescriptorCertEncryptionNodes as $keyDescriptorCertEncryptionNode) {
                             $metadataInfo['idp']['x509certMulti']['encryption'][] = OneLogin_Saml2_Utils::formatCert($keyDescriptorCertEncryptionNode->nodeValue, false);
                         }

--- a/lib/Saml2/IdPMetadataParser.php
+++ b/lib/Saml2/IdPMetadataParser.php
@@ -79,6 +79,7 @@ class OneLogin_Saml2_IdPMetadataParser
      * @param string $desiredNameIdFormat   If available on IdP metadata, use that nameIdFormat
      *
      * @return array metadata info in php-saml settings format
+     * @throws \Exception
      */
     public static function parseXML($xml, $entityId = null, $desiredNameIdFormat = null)
     {

--- a/lib/Saml2/LogoutResponse.php
+++ b/lib/Saml2/LogoutResponse.php
@@ -32,7 +32,7 @@ class OneLogin_Saml2_LogoutResponse
 
     /**
     * After execute a validation process, if it fails, this var contains the cause
-    * @var string
+    * @var string|null
     */
     private $_error;
 

--- a/lib/Saml2/LogoutResponse.php
+++ b/lib/Saml2/LogoutResponse.php
@@ -87,7 +87,7 @@ class OneLogin_Saml2_LogoutResponse
     /**
      * Gets the Status of the Logout Response.
      *
-     * @return string The Status
+     * @return string|null The Status
      */
     public function getStatus()
     {

--- a/lib/Saml2/LogoutResponse.php
+++ b/lib/Saml2/LogoutResponse.php
@@ -271,7 +271,7 @@ LOGOUTRESPONSE;
     }
 
    /**
-    * @return the ID of the Response
+    * @return string the ID of the Response
     */
     public function getId()
     {

--- a/lib/Saml2/Response.php
+++ b/lib/Saml2/Response.php
@@ -426,7 +426,7 @@ class OneLogin_Saml2_Response
     public function getAssertionId()
     {
         if (!$this->validateNumAssertions()) {
-            throw new IllegalArgumentException("SAML Response must contain 1 Assertion.");
+            throw new InvalidArgumentException("SAML Response must contain 1 Assertion.");
         }
         $assertionNodes = $this->_queryAssertion("");
         $id = null;

--- a/lib/Saml2/Response.php
+++ b/lib/Saml2/Response.php
@@ -409,7 +409,7 @@ class OneLogin_Saml2_Response
     }
 
     /**
-     * @return the ID of the Response
+     * @return string|null the ID of the Response
      */
     public function getId()
     {
@@ -421,7 +421,7 @@ class OneLogin_Saml2_Response
     }
 
     /**
-     * @return the ID of the assertion in the Response
+     * @return string|null the ID of the assertion in the Response
      */
     public function getAssertionId()
     {

--- a/lib/Saml2/Response.php
+++ b/lib/Saml2/Response.php
@@ -623,7 +623,7 @@ class OneLogin_Saml2_Response
     /**
      * Gets the NameID provided by the SAML response from the IdP.
      *
-     * @return string Name ID Value
+     * @return string|null Name ID Value
      */
     public function getNameId()
     {
@@ -638,7 +638,7 @@ class OneLogin_Saml2_Response
     /**
      * Gets the NameID Format provided by the SAML response from the IdP.
      *
-     * @return string Name ID Format
+     * @return string|null Name ID Format
      */
     public function getNameIdFormat()
     {
@@ -653,7 +653,7 @@ class OneLogin_Saml2_Response
     /**
      * Gets the NameID NameQualifier provided by the SAML response from the IdP.
      *
-     * @return string Name ID NameQualifier
+     * @return string|null Name ID NameQualifier
      */
     public function getNameIdNameQualifier()
     {

--- a/lib/Saml2/Response.php
+++ b/lib/Saml2/Response.php
@@ -47,7 +47,7 @@ class OneLogin_Saml2_Response
     /**
      * NotOnOrAfter value of a valid SubjectConfirmationData node
      *
-     * @var DateTime
+     * @var int
      */
     private $_validSCDNotOnOrAfter;
 
@@ -439,7 +439,8 @@ class OneLogin_Saml2_Response
     }
 
     /**
-     * @return the NotOnOrAfter value of the valid SubjectConfirmationData *         node if any
+     * @return int the NotOnOrAfter value of the valid SubjectConfirmationData
+     * node if any
      */
     public function getAssertionNotOnOrAfter()
     {

--- a/lib/Saml2/Response.php
+++ b/lib/Saml2/Response.php
@@ -525,6 +525,7 @@ class OneLogin_Saml2_Response
      * Gets the Issuers (from Response and Assertion).
      *
      * @return array @issuers The issuers of the assertion/response
+     * @throws OneLogin_Saml2_ValidationError
      */
     public function getIssuers()
     {

--- a/lib/Saml2/Settings.php
+++ b/lib/Saml2/Settings.php
@@ -288,6 +288,7 @@ class OneLogin_Saml2_Settings
      *
      * @return bool True if the settings info is valid
      * @throws OneLogin_Saml2_Error
+     * @suppress PhanUndeclaredVariable
      */
     private function _loadSettingsFromFile()
     {
@@ -301,13 +302,15 @@ class OneLogin_Saml2_Settings
             );
         }
 
-        include $filename;
+        /** @var array $settings */
+		include $filename;
 
         // Add advance_settings if exists
 
         $advancedFilename = $this->getConfigPath().'advanced_settings.php';
 
         if (file_exists($advancedFilename)) {
+            /** @var array $advancedSettings */
             include $advancedFilename;
             $settings = array_merge($settings, $advancedSettings);
         }

--- a/lib/Saml2/Settings.php
+++ b/lib/Saml2/Settings.php
@@ -1050,7 +1050,7 @@ class OneLogin_Saml2_Settings
     /**
      * Sets the IdP certificate.
      *
-     * @param string $value IdP certificate
+     * @param string $cert IdP certificate
      */
     public function setIdPCert($cert)
     {

--- a/lib/Saml2/Settings.php
+++ b/lib/Saml2/Settings.php
@@ -997,6 +997,7 @@ class OneLogin_Saml2_Settings
      * Activates or deactivates the strict mode.
      *
      * @param bool $value Strict parameter
+     * @throws Exception
      */
     public function setStrict($value)
     {

--- a/lib/Saml2/Settings.php
+++ b/lib/Saml2/Settings.php
@@ -88,7 +88,7 @@ class OneLogin_Saml2_Settings
     /**
      * Setting errors.
      *
-     * @var array
+     * @var bool
      */
     private $_spValidationOnly = false;
 
@@ -98,6 +98,7 @@ class OneLogin_Saml2_Settings
      * - Loads settings info from settings file or array/object provided
      *
      * @param array|object|null $settings SAML Toolkit Settings
+     * @param bool $spValidationOnly
      *
      * @throws OneLogin_Saml2_Error If any settings parameter is invalid
      * @throws Exception If OneLogin_Saml2_Settings is incorrectly supplied

--- a/lib/Saml2/Settings.php
+++ b/lib/Saml2/Settings.php
@@ -150,6 +150,7 @@ class OneLogin_Saml2_Settings
 
     /**
      * Sets the paths of the different folders
+	 * @suppress PhanUndeclaredConstant
      */
     private function _loadPaths()
     {

--- a/lib/Saml2/Utils.php
+++ b/lib/Saml2/Utils.php
@@ -18,22 +18,22 @@ class OneLogin_Saml2_Utils
 
 
     /**
-     * @var string
+     * @var string|null
      */
     private static $_host;
 
     /**
-     * @var string
+     * @var string|null
      */
     private static $_protocol;
 
     /**
-     * @var int
+     * @var int|null
      */
     private static $_port;
 
     /**
-     * @var string
+     * @var string|null
      */
     private static $_baseurlpath;
 

--- a/lib/Saml2/Utils.php
+++ b/lib/Saml2/Utils.php
@@ -644,7 +644,7 @@ class OneLogin_Saml2_Utils
      */
     public static function generateUniqueID()
     {
-        return 'ONELOGIN_' . sha1(uniqid(mt_rand(), true));
+        return 'ONELOGIN_' . sha1(uniqid((string)mt_rand(), true));
     }
 
     /**

--- a/lib/Saml2/Utils.php
+++ b/lib/Saml2/Utils.php
@@ -800,7 +800,7 @@ class OneLogin_Saml2_Utils
      * @param string $cacheDuration The duration, as a string.
      * @param string $validUntil    The valid until date, as a string or as a timestamp
      *
-     * @return int $expireTime  The expiration time.
+     * @return int|null $expireTime  The expiration time.
      */
     public static function getExpireTime($cacheDuration = null, $validUntil = null)
     {

--- a/lib/Saml2/Utils.php
+++ b/lib/Saml2/Utils.php
@@ -884,6 +884,7 @@ class OneLogin_Saml2_Utils
      * Calculates the fingerprint of a x509cert.
      *
      * @param string $x509cert x509 cert
+     * @param string $alg
      *
      * @return null|string Formatted fingerprint
      */

--- a/lib/Saml2/Utils.php
+++ b/lib/Saml2/Utils.php
@@ -651,7 +651,7 @@ class OneLogin_Saml2_Utils
      * Converts a UNIX timestamp to SAML2 timestamp on the form
      * yyyy-mm-ddThh:mm:ss(\.s+)?Z.
      *
-     * @param string $time The time we should convert (DateTime).
+     * @param string|int $time The time we should convert (DateTime).
      *
      * @return string $timestamp SAML2 timestamp.
      */

--- a/lib/Saml2/Utils.php
+++ b/lib/Saml2/Utils.php
@@ -73,7 +73,7 @@ class OneLogin_Saml2_Utils
      *
      * @throws Exception
      *
-     * @return DOMDocument $dom The result of load the XML at the DomDocument
+     * @return DOMDocument|false $dom The result of load the XML at the DomDocument
      */
     public static function loadXML($dom, $xml)
     {

--- a/lib/Saml2/Utils.php
+++ b/lib/Saml2/Utils.php
@@ -725,6 +725,7 @@ class OneLogin_Saml2_Utils
 
         /* Parse the duration. We use a very strict pattern. */
         $durationRegEx = '#^(-?)P(?:(?:(?:(\\d+)Y)?(?:(\\d+)M)?(?:(\\d+)D)?(?:T(?:(\\d+)H)?(?:(\\d+)M)?(?:(\\d+)S)?)?)|(?:(\\d+)W))$#D';
+        $matches = [];
         if (!preg_match($durationRegEx, $duration, $matches)) {
             throw new Exception('Invalid ISO 8601 duration: ' . $duration);
         }


### PR DESCRIPTION
I'm in the process of getting https://github.com/phan/phan running on this code base for static source code analysis, this PR already fixes most of the errors. There are some left that I'll tackle later on. It's probably best to go through every commit on its own.

Once all issues are fixed we can then run phan as a CI step on Travis :)

In addition, it also fixes a real bug in 8824c09a1699434d0dac726a8b291d11f0fd35f6. `IllegalArgumentException` doesn't exist in PHP while `InvalidArgumentException` does:

```
lib/Saml2/Response.php:429 PhanUndeclaredClassMethod Call to method __construct from undeclared class \IllegalArgumentException
```