### PR TITLE
3.0.0  Signature validation fails when using ADFS 3.0 as IdP with encryption

### DIFF
--- a/lib/Saml2/Response.php
+++ b/lib/Saml2/Response.php
@@ -1084,12 +1084,14 @@ class OneLogin_Saml2_Response
             $objKey->loadKey($key);
         }
 
-        $decrypted = $objenc->decryptNode($objKey, true);
-
-        if ($decrypted instanceof DOMDocument) {
+        $decryptedXML = $objenc->decryptNode($objKey, false);
+        $decrypted = new DOMDocument();
+        $decrypted->loadXML($decryptedXML);
+        if ($encData->parentNode instanceof DOMDocument) {
             return $decrypted;
         } else {
-            $encryptedAssertion = $decrypted->parentNode;
+            $decrypted = $decrypted->documentElement;
+            $encryptedAssertion = $encData->parentNode;
             $container = $encryptedAssertion->parentNode;
 
             // Fix possible issue with saml namespace
@@ -1106,13 +1108,10 @@ class OneLogin_Saml2_Response
                 } else {
                     $ns = 'xmlns';
                 }
-
                 $decrypted->setAttributeNS('http://www.w3.org/2000/xmlns/', $ns, OneLogin_Saml2_Constants::NS_SAML);
             }
-
-            $container->replaceChild($decrypted, $encryptedAssertion);
-
-            return $decrypted->ownerDocument;
+            OneLogin_Saml2_Utils::treeCopyReplace($encryptedAssertion, $decrypted);
+            return $container->ownerDocument;
         }
     }
 

--- a/lib/Saml2/Response.php
+++ b/lib/Saml2/Response.php
@@ -1086,7 +1086,10 @@ class OneLogin_Saml2_Response
 
         $decryptedXML = $objenc->decryptNode($objKey, false);
         $decrypted = new DOMDocument();
-        $decrypted->loadXML($decryptedXML);
+        $check = OneLogin_Saml2_Utils::loadXML($decrypted, $decryptedXML);
+        if ($check === false) {
+            throw new Exception('Error: string from decrypted assertion could not be loaded into a XML document');
+        }
         if ($encData->parentNode instanceof DOMDocument) {
             return $decrypted;
         } else {

--- a/lib/Saml2/Utils.php
+++ b/lib/Saml2/Utils.php
@@ -158,6 +158,47 @@ class OneLogin_Saml2_Utils
     }
 
     /**
+     * Import a node tree into a target document
+     * Copy it before a reference node as a sibling
+     * and at the end of the copy remove
+     * the reference node in the target document
+     * As it were 'replacing' it
+     * Leaving nested default namespaces alone
+     * (Standard importNode with deep copy
+     *  mangles nested default namespaces)
+     *
+     * The reference node must not be a DomDocument
+     * It CAN be the top element of a document
+     * Returns the copied node in the target document
+     *
+     * @param DomNode $targetNode
+     * @param DomNode $sourceNode
+     * @param bool $recurse
+     * @return DOMNode
+     * @throws Exception
+     */
+    public static function treeCopyReplace(DomNode $targetNode, DomNode $sourceNode, $recurse=false) {
+        if ($targetNode->parentNode === null) {
+            throw new Exception('Illegal argument targetNode. It has no parentNode.');
+        }
+        $clonedNode = $targetNode->ownerDocument->importNode($sourceNode, false);
+        if ($recurse) {
+            $resultNode = $targetNode->appendChild($clonedNode);
+        } else {
+            $resultNode = $targetNode->parentNode->insertBefore($clonedNode, $targetNode);
+        }
+        if ($sourceNode->childNodes !== null) {
+            foreach($sourceNode->childNodes as $child) {
+                self::treeCopyReplace($resultNode, $child, true);
+            }
+        }
+        if (!$recurse) {
+            $targetNode->parentNode->removeChild($targetNode);
+        }
+        return $resultNode;
+    }
+
+    /**
      * Returns a x509 cert (adding header & footer if required).
      *
      * @param string $cert  A x509 unformated cert


### PR DESCRIPTION
I am offering a new method of importing a decrypted assertion into the XML document to replace the EncryptedAssertion. This method should solve the problem of Assertions using default namespace declarations which get mangled by importNode with deep cloning and then do not pass signature verification.

This solves problems when the IdP signs its assertion and encrypts it, AND uses default namespaces in the Assertion elements. As for example with ADFS 3.0.