### PR TITLE
Change Fatal Error to Exception

### DIFF
--- a/lib/Saml2/LogoutRequest.php
+++ b/lib/Saml2/LogoutRequest.php
@@ -163,7 +163,7 @@ LOGOUTREQUEST;
 
             if (false === $dom) {
                 throw new OneLogin_Saml2_Error(
-                    "XML is invalid",
+                    "LogoutRequest could not be processed",
                     OneLogin_Saml2_Error::SAML_LOGOUTREQUEST_INVALID
                 );
             }

--- a/lib/Saml2/LogoutRequest.php
+++ b/lib/Saml2/LogoutRequest.php
@@ -160,7 +160,7 @@ LOGOUTREQUEST;
         } else {
             $dom = new DOMDocument();
             $dom = OneLogin_Saml2_Utils::loadXML($dom, $request);
-            
+
             if (false === $dom) {
                 throw new OneLogin_Saml2_Error(
                     "XML is invalid",

--- a/lib/Saml2/LogoutRequest.php
+++ b/lib/Saml2/LogoutRequest.php
@@ -150,6 +150,8 @@ LOGOUTREQUEST;
      * @param string|DOMDocument $request Logout Request Message
      *
      * @return string ID
+     *
+     * @throws OneLogin_Saml2_Error
      */
     public static function getID($request)
     {
@@ -158,6 +160,13 @@ LOGOUTREQUEST;
         } else {
             $dom = new DOMDocument();
             $dom = OneLogin_Saml2_Utils::loadXML($dom, $request);
+            
+            if (false === $dom) {
+                throw new OneLogin_Saml2_Error(
+                    "XML is invalid",
+                    OneLogin_Saml2_Error::SAML_LOGOUTREQUEST_INVALID
+                );
+            }
         }
 
         $id = $dom->documentElement->getAttribute('ID');

--- a/lib/Saml2/LogoutResponse.php
+++ b/lib/Saml2/LogoutResponse.php
@@ -67,7 +67,7 @@ class OneLogin_Saml2_LogoutResponse
 
             if (false === $this->document) {
                 throw new OneLogin_Saml2_Error(
-                    "XML is invalid",
+                    "LogoutResponse could not be processed",
                     OneLogin_Saml2_Error::SAML_LOGOUTRESPONSE_INVALID
                 );
             }

--- a/lib/Saml2/LogoutResponse.php
+++ b/lib/Saml2/LogoutResponse.php
@@ -42,6 +42,8 @@ class OneLogin_Saml2_LogoutResponse
      *
      * @param OneLogin_Saml2_Settings $settings Settings.
      * @param string|null             $response An UUEncoded SAML Logout response from the IdP.
+     *
+     * @throws OneLogin_Saml2_Error
      */
     public function __construct(OneLogin_Saml2_Settings $settings, $response = null)
     {
@@ -62,6 +64,13 @@ class OneLogin_Saml2_LogoutResponse
             }
             $this->document = new DOMDocument();
             $this->document = OneLogin_Saml2_Utils::loadXML($this->document, $this->_logoutResponse);
+
+            if (false === $this->document) {
+                throw new OneLogin_Saml2_Error(
+                    "XML is invalid",
+                    OneLogin_Saml2_Error::SAML_LOGOUTRESPONSE_INVALID
+                );
+            }
 
             if ($this->document->documentElement->hasAttribute('ID')) {
                 $this->id = $this->document->documentElement->getAttribute('ID');

--- a/lib/Saml2/Utils.php
+++ b/lib/Saml2/Utils.php
@@ -727,7 +727,7 @@ class OneLogin_Saml2_Utils
 
         /* Parse the duration. We use a very strict pattern. */
         $durationRegEx = '#^(-?)P(?:(?:(?:(\\d+)Y)?(?:(\\d+)M)?(?:(\\d+)D)?(?:T(?:(\\d+)H)?(?:(\\d+)M)?(?:(\\d+)S)?)?)|(?:(\\d+)W))$#D';
-        $matches = array(); 
+        $matches = array();
         if (!preg_match($durationRegEx, $duration, $matches)) {
             throw new Exception('Invalid ISO 8601 duration: ' . $duration);
         }

--- a/tests/src/OneLogin/Saml2/LogoutRequestTest.php
+++ b/tests/src/OneLogin/Saml2/LogoutRequestTest.php
@@ -861,7 +861,7 @@ class OneLogin_Saml2_LogoutRequestTest extends PHPUnit_Framework_TestCase
      * @covers OneLogin_Saml2_LogoutRequest::getID()
      *
      * @expectedException OneLogin_Saml2_Error
-     * @expectedExceptionMessage XML is invalid
+     * @expectedExceptionMessage LogoutRequest could not be processed
      */
     public function testGetIDException()
     {

--- a/tests/src/OneLogin/Saml2/LogoutRequestTest.php
+++ b/tests/src/OneLogin/Saml2/LogoutRequestTest.php
@@ -265,7 +265,7 @@ class OneLogin_Saml2_LogoutRequestTest extends PHPUnit_Framework_TestCase
     /**
     * Tests the OneLogin_Saml2_LogoutRequest Constructor.
     * Case: Able to generate encryptedID with MultiCert
-    * 
+    *
     * @covers OneLogin_Saml2_LogoutRequest
     */
     public function testConstructorEncryptIdUsingX509certMulti()
@@ -828,7 +828,7 @@ class OneLogin_Saml2_LogoutRequestTest extends PHPUnit_Framework_TestCase
         $logoutRequest = new OneLogin_Saml2_LogoutRequest($settings);
         $xml = $logoutRequest->getXML();
         $this->assertRegExp('#^<samlp:LogoutRequest#', $xml);
-    
+
         $logoutRequestProcessed = new OneLogin_Saml2_LogoutRequest($settings, base64_encode($xml));
         $xml2 = $logoutRequestProcessed->getXML();
         $this->assertRegExp('#^<samlp:LogoutRequest#', $xml2);
@@ -849,9 +849,28 @@ class OneLogin_Saml2_LogoutRequestTest extends PHPUnit_Framework_TestCase
         $xml = $logoutRequest->getXML();
         $id1 = OneLogin_Saml2_LogoutRequest::getID($xml);
         $this->assertNotNull($id1);
-    
+
         $logoutRequestProcessed = new OneLogin_Saml2_LogoutRequest($settings, base64_encode($xml));
         $id2 = $logoutRequestProcessed->id;
         $this->assertEquals($id1, $id2);
+    }
+
+    /**
+     * Tests that the LogoutRequest throws an exception
+     *
+     * @covers OneLogin_Saml2_LogoutRequest::getID()
+     *
+     * @expectedException OneLogin_Saml2_Error
+     * @expectedExceptionMessage XML is invalid
+     */
+    public function testGetIDException()
+    {
+        $settingsDir = TEST_ROOT .'/settings/';
+        include $settingsDir.'settings1.php';
+
+        $settings = new OneLogin_Saml2_Settings($settingsInfo);
+        $logoutRequest = new OneLogin_Saml2_LogoutRequest($settings);
+        $xml = $logoutRequest->getXML();
+        $id1 = OneLogin_Saml2_LogoutRequest::getID($xml.'<garbage>');
     }
 }

--- a/tests/src/OneLogin/Saml2/LogoutResponseTest.php
+++ b/tests/src/OneLogin/Saml2/LogoutResponseTest.php
@@ -437,7 +437,7 @@ class OneLogin_Saml2_LogoutResponseTest extends PHPUnit_Framework_TestCase
         //Test that we can choose not to compress the request payload.
         $settingsDir = TEST_ROOT .'/settings/';
         include $settingsDir.'settings1.php';
-        
+
         //Compression is currently turned on in settings.
         $settings = new OneLogin_Saml2_Settings($settingsInfo);
         $logoutResponse = new OneLogin_Saml2_LogoutResponse($settings, $message);
@@ -448,7 +448,7 @@ class OneLogin_Saml2_LogoutResponseTest extends PHPUnit_Framework_TestCase
         //Test that we can choose not to compress the request payload.
         $settingsDir = TEST_ROOT .'/settings/';
         include $settingsDir.'settings2.php';
-        
+
         //Compression is currently turned on in settings.
         $settings = new OneLogin_Saml2_Settings($settingsInfo);
         $logoutResponse = new OneLogin_Saml2_LogoutResponse($settings, $message);
@@ -497,9 +497,26 @@ class OneLogin_Saml2_LogoutResponseTest extends PHPUnit_Framework_TestCase
         $xml = $logoutResponse->getXML();
         $id1 = $logoutResponse->getID();
         $this->assertNotNull($id1);
-    
+
         $processedLogoutResponse = new OneLogin_Saml2_LogoutResponse($settings, base64_encode($xml));
         $id2 = $processedLogoutResponse->getID();
         $this->assertEquals($id1, $id2);
+    }
+
+    /**
+     * Tests that the LogoutRequest throws an exception
+     *
+     * @covers OneLogin_Saml2_LogoutRequest::getID()
+     *
+     * @expectedException OneLogin_Saml2_Error
+     * @expectedExceptionMessage XML is invalid
+     */
+    public function testGetIDException()
+    {
+        $settingsDir = TEST_ROOT .'/settings/';
+        include $settingsDir.'settings1.php';
+
+        $settings = new OneLogin_Saml2_Settings($settingsInfo);
+        $logoutResponse = new OneLogin_Saml2_LogoutResponse($settings, '<garbage>');
     }
 }

--- a/tests/src/OneLogin/Saml2/LogoutResponseTest.php
+++ b/tests/src/OneLogin/Saml2/LogoutResponseTest.php
@@ -509,7 +509,7 @@ class OneLogin_Saml2_LogoutResponseTest extends PHPUnit_Framework_TestCase
      * @covers OneLogin_Saml2_LogoutRequest::getID()
      *
      * @expectedException OneLogin_Saml2_Error
-     * @expectedExceptionMessage XML is invalid
+     * @expectedExceptionMessage LogoutResponse could not be processed
      */
     public function testGetIDException()
     {


### PR DESCRIPTION
`OneLogin_Saml2_Utils::loadXML` returns `false` if input is not correct XML.

Which leads to a Fatal Error :

> Call to a member function getAttribute() on null in **/vendor/onelogin/php-saml/lib/Saml2/LogoutRequest.php:163

With this fix, an Exception is thrown instead.