### PR TITLE
Fixes #287: Changes return type of OneLogin_Saml2_Auth::getSessionExpiration() from DateTime to int to be consistent with what is actually returned.

### DIFF
--- a/lib/Saml2/Auth.php
+++ b/lib/Saml2/Auth.php
@@ -394,7 +394,7 @@ class OneLogin_Saml2_Auth
     /**
      * Returns the SessionNotOnOrAfter
      *
-     * @return DateTime|null  The SessionNotOnOrAfter of the assertion
+     * @return int|null  The SessionNotOnOrAfter of the assertion
      */
     public function getSessionExpiration()
     {


### PR DESCRIPTION
Fixes #287