### PR TITLE
Clean the composer.json file

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,6 @@
     "name": "onelogin/php-saml",
     "description": "OneLogin PHP SAML Toolkit",
     "license": "MIT",
-    "version": "3.0.0",
     "homepage": "https://developers.onelogin.com/saml/php",
     "keywords": ["saml", "saml2", "onelogin"],
     "autoload": {
@@ -17,15 +16,15 @@
     },
     "require": {
         "php": ">=5.4",
-        "robrichards/xmlseclibs": ">=3.0"
+        "robrichards/xmlseclibs": "^3.0"
     },
     "require-dev": {
-        "phpunit/phpunit": ">=4.8",
-        "satooshi/php-coveralls": ">=1.0.2",
-        "sebastian/phpcpd": "*",
-        "phploc/phploc": "*",
-        "pdepend/pdepend": ">=2.5.0",
-        "squizlabs/php_codesniffer": "~3.1.1"
+        "phpunit/phpunit": "^4.8.35 || ^5.7 || ^6.5 || ^7.1",
+        "php-coveralls/php-coveralls": "^1.0.2 || ^2.0",
+        "sebastian/phpcpd": "^2.0 || ^3.0 || ^4.0",
+        "phploc/phploc": "^2.1 || ^3.0 || ^4.0",
+        "pdepend/pdepend": "^2.5.0",
+        "squizlabs/php_codesniffer": "^3.1.1"
     },
     "suggest": {
         "ext-openssl": "Install openssl lib in order to handle with x509 certs (require to support sign and encryption)",


### PR DESCRIPTION
- remove the explicit version, as this has only drawbacks when managing the package in Git, as composer extracts the version from Git anyway
- use bound constraints
- use the new name for the php-coveralls package