### PR TITLE
Use array typehints for array arguments

### DIFF
--- a/src/Saml2/Auth.php
+++ b/src/Saml2/Auth.php
@@ -332,10 +332,9 @@ class Auth
      *
      * @return string|null
      */
-    public function redirectTo($url = '', $parameters = array(), $stay = false)
+    public function redirectTo($url = '', array $parameters = array(), $stay = false)
     {
         assert(is_string($url));
-        assert(is_array($parameters));
 
         if (empty($url) && isset($_REQUEST['RelayState'])) {
             $url = $_REQUEST['RelayState'];
@@ -475,10 +474,8 @@ class Auth
      *
      * @return string|null If $stay is True, it return a string with the SLO URL + LogoutRequest + parameters
      */
-    public function login($returnTo = null, $parameters = array(), $forceAuthn = false, $isPassive = false, $stay = false, $setNameIdPolicy = true)
+    public function login($returnTo = null, array $parameters = array(), $forceAuthn = false, $isPassive = false, $stay = false, $setNameIdPolicy = true)
     {
-        assert(is_array($parameters));
-
         $authnRequest = new AuthnRequest($this->_settings, $forceAuthn, $isPassive, $setNameIdPolicy);
 
         $this->_lastRequest = $authnRequest->getXML();
@@ -513,14 +510,12 @@ class Auth
      * @param string|null $nameIdFormat        The NameID Format will be set in the LogoutRequest.
      * @param string|null $nameIdNameQualifier The NameID NameQualifier will be set in the LogoutRequest.
      *
-     * @return If $stay is True, it return a string with the SLO URL + LogoutRequest + parameters
+     * @return string|null If $stay is True, it return a string with the SLO URL + LogoutRequest + parameters
      *
      * @throws Error
      */
-    public function logout($returnTo = null, $parameters = array(), $nameId = null, $sessionIndex = null, $stay = false, $nameIdFormat = null, $nameIdNameQualifier = null)
+    public function logout($returnTo = null, array $parameters = array(), $nameId = null, $sessionIndex = null, $stay = false, $nameIdFormat = null, $nameIdNameQualifier = null)
     {
-        assert(is_array($parameters));
-
         $sloUrl = $this->getSLOurl();
         if (empty($sloUrl)) {
             throw new Error(

--- a/src/Saml2/Settings.php
+++ b/src/Saml2/Settings.php
@@ -245,7 +245,7 @@ class Settings
      *
      * @return bool True if the settings info is valid
      */
-    private function _loadSettingsFromArray($settings)
+    private function _loadSettingsFromArray(array $settings)
     {
         if (isset($settings['sp'])) {
             $this->_sp = $settings['sp'];
@@ -444,11 +444,9 @@ class Settings
      *
      * @return array $errors  Errors found on the settings data
      */
-    public function checkSettings($settings)
+    public function checkSettings(array $settings)
     {
-        assert(is_array($settings));
-
-        if (!is_array($settings) || empty($settings)) {
+        if (empty($settings)) {
             $errors = array('invalid_syntax');
         } else {
             $errors = array();
@@ -502,11 +500,9 @@ class Settings
      *
      * @return array $errors  Errors found on the IdP settings data
      */
-    public function checkIdPSettings($settings)
+    public function checkIdPSettings(array $settings)
     {
-        assert(is_array($settings));
-
-        if (!is_array($settings) || empty($settings)) {
+        if (empty($settings)) {
             return array('invalid_syntax');
         }
 
@@ -567,11 +563,9 @@ class Settings
      *
      * @return array $errors  Errors found on the SP settings data
      */
-    public function checkSPSettings($settings)
+    public function checkSPSettings(array $settings)
     {
-        assert(is_array($settings));
-
-        if (!is_array($settings) || empty($settings)) {
+        if (empty($settings)) {
             return array('invalid_syntax');
         }
 
@@ -900,7 +894,7 @@ class Settings
      *
      * @param string $xml Metadata's XML that will be validate
      *
-     * @return Array The list of found errors
+     * @return array The list of found errors
      */
     public function validateMetadata($xml)
     {

--- a/src/Saml2/Utils.php
+++ b/src/Saml2/Utils.php
@@ -237,10 +237,9 @@ class Utils
      *
      * @throws Error
      */
-    public static function redirect($url, $parameters = array(), $stay = false)
+    public static function redirect($url, array $parameters = array(), $stay = false)
     {
         assert(is_string($url));
-        assert(is_array($parameters));
 
         if (substr($url, 0, 1) === '/') {
             $url = self::getSelfURLhost() . $url;


### PR DESCRIPTION
Assertions are not blocking the invalid input by default (they might get disabled entirely or be configured to trigger only a warning). Using an array typehint is better to enforce the contract.

Remaining assertions are about scalar types, which cannot go to the method signature until the min PHP requirements is bumped to PHP 7.0.