### PR TITLE
Security by Default: make strict true by default

### DIFF
--- a/src/Saml2/Settings.php
+++ b/src/Saml2/Settings.php
@@ -45,7 +45,7 @@ class Settings
      *
      * @var bool
      */
-    private $_strict = false;
+    private $_strict = true;
 
     /**
      * Activate debug mode

--- a/tests/src/OneLogin/Saml2/SettingsTest.php
+++ b/tests/src/OneLogin/Saml2/SettingsTest.php
@@ -1000,7 +1000,7 @@ class SettingsTest extends \PHPUnit\Framework\TestCase
         unset($settingsInfo['strict']);
 
         $settings = new Settings($settingsInfo);
-        $this->assertFalse($settings->isStrict());
+        $this->assertTrue($settings->isStrict());
 
         $settingsInfo['strict'] = false;
         $settings2 = new Settings($settingsInfo);


### PR DESCRIPTION
The mantra should be "secure by default"; being able to disable strict is great if you need it while developing/testing but it should always be preverable to enable strict mode. Even when developing/testing, you should be as close to production settings as possible because otherwise you might run into nasty suprises and as the readme already says:

> In production, the strict parameter MUST be set as "true"

`signatureAlgorithm` and `digestAlgorithm` which are mentioned afterwards are already set to secure defaults.

Perhaps this also requires some small documentation/example changes, let me know if/where that is necessairy and i'll include it 😄 