### PR TITLE
[style] Remove space after array constructor

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,7 +242,7 @@ file, rename and edit it.
 ```php
 <?php
 
-$settings = array (
+$settings = array(
     // If 'strict' is True, then the PHP Toolkit will reject unsigned
     // or unencrypted messages if it expects them to be signed or encrypted.
     // Also it will reject the messages if the SAML standard is not strictly
@@ -259,12 +259,12 @@ $settings = array (
     'baseurl' => null,
 
     // Service Provider Data that we are deploying.
-    'sp' => array (
+    'sp' => array(
         // Identifier of the SP entity  (must be a URI)
         'entityId' => '',
         // Specifies info about where and how the <AuthnResponse> message MUST be
         // returned to the requester, in this case our SP.
-        'assertionConsumerService' => array (
+        'assertionConsumerService' => array(
             // URL Location where the <Response> from the IdP will be returned
             'url' => '',
             // SAML protocol binding to be used when returning the <Response>
@@ -290,7 +290,7 @@ $settings = array (
         ),
         // Specifies info about where and how the <Logout Response> message MUST be
         // returned to the requester, in this case our SP.
-        'singleLogoutService' => array (
+        'singleLogoutService' => array(
             // URL Location where the <Response> from the IdP will be returned
             'url' => '',
             // SAML protocol binding to be used when returning the <Response>
@@ -318,11 +318,11 @@ $settings = array (
     ),
 
     // Identity Provider Data that we want connected with our SP.
-    'idp' => array (
+    'idp' => array(
         // Identifier of the IdP entity  (must be a URI)
         'entityId' => '',
         // SSO endpoint info of the IdP. (Authentication Request protocol)
-        'singleSignOnService' => array (
+        'singleSignOnService' => array(
             // URL Target of the IdP where the Authentication Request Message
             // will be sent.
             'url' => '',
@@ -332,7 +332,7 @@ $settings = array (
             'binding' => 'urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect',
         ),
         // SLO endpoint info of the IdP.
-        'singleLogoutService' => array (
+        'singleLogoutService' => array(
             // URL Location of the IdP where SLO Request will be sent.
             'url' => '',
             // SAML protocol binding to be used when returning the <Response>
@@ -386,15 +386,15 @@ that you can copy and rename it as `advanced_settings.php`
 ```php
 <?php
 
-$advancedSettings = array (
+$advancedSettings = array(
 
     // Compression settings
-    'compress' => array (
+    'compress' => array(
         'requests' => true,
         'responses' => true
     ),
     // Security settings
-    'security' => array (
+    'security' => array(
 
         /** signatures and encryptions offered */
 
@@ -415,7 +415,7 @@ $advancedSettings = array (
         'logoutResponseSigned' => false,
 
         /* Sign the Metadata
-         False || True (use sp certs) || array (
+         False || True (use sp certs) || array(
                                                     keyFileName => 'metadata.key',
                                                     certFileName => 'metadata.crt'
                                                 )
@@ -447,7 +447,7 @@ $advancedSettings = array (
         // Authentication context.
         // Set to false and no AuthContext will be sent in the AuthNRequest.
         // Set true or don't present this parameter and you will get an AuthContext 'exact' 'urn:oasis:names:tc:SAML:2.0:ac:classes:PasswordProtectedTransport'.
-        // Set an array with the possible auth context values: array ('urn:oasis:names:tc:SAML:2.0:ac:classes:Password', 'urn:oasis:names:tc:SAML:2.0:ac:classes:X509').
+        // Set an array with the possible auth context values: array('urn:oasis:names:tc:SAML:2.0:ac:classes:Password', 'urn:oasis:names:tc:SAML:2.0:ac:classes:X509').
         'requestedAuthnContext' => true,
 
         // Indicates if the SP will validate all received xmls.
@@ -482,12 +482,12 @@ $advancedSettings = array (
 
     // Contact information template, it is recommended to supply a
     // technical and support contacts.
-    'contactPerson' => array (
-        'technical' => array (
+    'contactPerson' => array(
+        'technical' => array(
             'givenName' => '',
             'emailAddress' => ''
         ),
-        'support' => array (
+        'support' => array(
             'givenName' => '',
             'emailAddress' => ''
         ),
@@ -495,7 +495,7 @@ $advancedSettings = array (
 
     // Organization information template, the info in en_US lang is
     // recomended, add more if required.
-    'organization' => array (
+    'organization' => array(
         'en-US' => array(
             'name' => '',
             'displayname' => '',

--- a/advanced_settings_example.php
+++ b/advanced_settings_example.php
@@ -1,18 +1,18 @@
 <?php
 
-$advancedSettings = array (
+$advancedSettings = array(
 
     // Compression settings
     // Handle if the getRequest/getResponse methods will return the Request/Response deflated.
     // But if we provide a $deflate boolean parameter to the getRequest or getResponse
     // method it will have priority over the compression settings.
-    'compress' => array (
+    'compress' => array(
         'requests' => true,
         'responses' => true
     ),
 
     // Security settings
-    'security' => array (
+    'security' => array(
 
         /** signatures and encryptions offered */
 
@@ -33,7 +33,7 @@ $advancedSettings = array (
         'logoutResponseSigned' => false,
 
         /* Sign the Metadata
-         False || True (use sp certs) || array (
+         False || True (use sp certs) || array(
                                                     keyFileName => 'metadata.key',
                                                     certFileName => 'metadata.crt'
                                                 )
@@ -66,7 +66,7 @@ $advancedSettings = array (
         // Authentication context.
         // Set to false and no AuthContext will be sent in the AuthNRequest,
         // Set true or don't present this parameter and you will get an AuthContext 'exact' 'urn:oasis:names:tc:SAML:2.0:ac:classes:PasswordProtectedTransport'
-        // Set an array with the possible auth context values: array ('urn:oasis:names:tc:SAML:2.0:ac:classes:Password', 'urn:oasis:names:tc:SAML:2.0:ac:classes:X509'),
+        // Set an array with the possible auth context values: array('urn:oasis:names:tc:SAML:2.0:ac:classes:Password', 'urn:oasis:names:tc:SAML:2.0:ac:classes:X509'),
         'requestedAuthnContext' => false,
 
         // Allows the authn comparison parameter to be set, defaults to 'exact' if
@@ -104,19 +104,19 @@ $advancedSettings = array (
     ),
 
     // Contact information template, it is recommended to suply a technical and support contacts
-    'contactPerson' => array (
-        'technical' => array (
+    'contactPerson' => array(
+        'technical' => array(
             'givenName' => '',
             'emailAddress' => ''
         ),
-        'support' => array (
+        'support' => array(
             'givenName' => '',
             'emailAddress' => ''
         ),
     ),
 
     // Organization information template, the info in en_US lang is recomended, add more if required
-    'organization' => array (
+    'organization' => array(
         'en-US' => array(
             'name' => '',
             'displayname' => '',

--- a/demo1/settings_example.php
+++ b/demo1/settings_example.php
@@ -2,23 +2,23 @@
 
     $spBaseUrl = 'https://<your_domain>'; //or http://<your_domain>
 
-    $settingsInfo = array (
-        'sp' => array (
+    $settingsInfo = array(
+        'sp' => array(
             'entityId' => $spBaseUrl.'/demo1/metadata.php',
-            'assertionConsumerService' => array (
+            'assertionConsumerService' => array(
                 'url' => $spBaseUrl.'/demo1/index.php?acs',
             ),
-            'singleLogoutService' => array (
+            'singleLogoutService' => array(
                 'url' => $spBaseUrl.'/demo1/index.php?sls',
             ),
             'NameIDFormat' => 'urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified',
         ),
-        'idp' => array (
+        'idp' => array(
             'entityId' => '',
-            'singleSignOnService' => array (
+            'singleSignOnService' => array(
                 'url' => '',
             ),
-            'singleLogoutService' => array (
+            'singleLogoutService' => array(
                 'url' => '',
             ),
             'x509cert' => '',

--- a/settings_example.php
+++ b/settings_example.php
@@ -1,6 +1,6 @@
 <?php
 
-$settings = array (
+$settings = array(
     // If 'strict' is True, then the PHP Toolkit will reject unsigned
     // or unencrypted messages if it expects them signed or encrypted
     // Also will reject the messages if not strictly follow the SAML
@@ -17,12 +17,12 @@ $settings = array (
     'baseurl' => null,
 
     // Service Provider Data that we are deploying
-    'sp' => array (
+    'sp' => array(
         // Identifier of the SP entity  (must be a URI)
         'entityId' => '',
         // Specifies info about where and how the <AuthnResponse> message MUST be
         // returned to the requester, in this case our SP.
-        'assertionConsumerService' => array (
+        'assertionConsumerService' => array(
             // URL Location where the <Response> from the IdP will be returned
             'url' => '',
             // SAML protocol binding to be used when returning the <Response>
@@ -48,7 +48,7 @@ $settings = array (
         ),
         // Specifies info about where and how the <Logout Response> message MUST be
         // returned to the requester, in this case our SP.
-        'singleLogoutService' => array (
+        'singleLogoutService' => array(
             // URL Location where the <Response> from the IdP will be returned
             'url' => '',
             // SAML protocol binding to be used when returning the <Response>
@@ -77,11 +77,11 @@ $settings = array (
     ),
 
     // Identity Provider Data that we want connect with our SP
-    'idp' => array (
+    'idp' => array(
         // Identifier of the IdP entity  (must be a URI)
         'entityId' => '',
         // SSO endpoint info of the IdP. (Authentication Request protocol)
-        'singleSignOnService' => array (
+        'singleSignOnService' => array(
             // URL Target of the IdP where the SP will send the Authentication Request Message
             'url' => '',
             // SAML protocol binding to be used when returning the <Response>
@@ -90,7 +90,7 @@ $settings = array (
             'binding' => 'urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect',
         ),
         // SLO endpoint info of the IdP.
-        'singleLogoutService' => array (
+        'singleLogoutService' => array(
             // URL Location of the IdP where the SP will send the SLO Request
             'url' => '',
             // SAML protocol binding to be used when returning the <Response>

--- a/src/Saml2/Settings.php
+++ b/src/Saml2/Settings.php
@@ -160,7 +160,7 @@ class Settings
     private function _loadPaths()
     {
         $basePath = dirname(dirname(__DIR__)) . '/';
-        $this->_paths = array (
+        $this->_paths = array(
             'base' => $basePath,
             'config' => $basePath,
             'cert' => $basePath.'certs/',

--- a/tests/data/customPath/advanced_settings.php
+++ b/tests/data/customPath/advanced_settings.php
@@ -1,7 +1,7 @@
 <?php
 
-    $advancedSettings = array (
-        'security' => array (
+    $advancedSettings = array(
+        'security' => array(
             'nameIdEncrypted' => false,
             'authnRequestsSigned' => false,
             'logoutRequestSigned' => false,

--- a/tests/data/customPath/settings.php
+++ b/tests/data/customPath/settings.php
@@ -1,21 +1,21 @@
 <?php
-    $settings = array (
-        'sp' => array (
+    $settings = array(
+        'sp' => array(
             'entityId' => 'http://stuff.com/endpoints/metadata.php',
-            'assertionConsumerService' => array (
+            'assertionConsumerService' => array(
                 'url' => 'http://stuff.com/endpoints/endpoints/acs.php',
             ),
-            'singleLogoutService' => array (
+            'singleLogoutService' => array(
                 'url' => 'http://stuff.com/endpoints/endpoints/sls.php',
             ),
             'NameIDFormat' => 'urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified',
         ),
-        'idp' => array (
+        'idp' => array(
             'entityId' => 'http://idp.example.com/',
-            'singleSignOnService' => array (
+            'singleSignOnService' => array(
                 'url' => 'http://idp.example.com/SSOService.php',
             ),
-            'singleLogoutService' => array (
+            'singleLogoutService' => array(
                 'url' => 'http://idp.example.com/SingleLogoutService.php',
             ),
             'x509cert' => 'MIICgTCCAeoCCQCbOlrWDdX7FTANBgkqhkiG9w0BAQUFADCBhDELMAkGA1UEBhMCTk8xGDAWBgNVBAgTD0FuZHJlYXMgU29sYmVyZzEMMAoGA1UEBxMDRm9vMRAwDgYDVQQKEwdVTklORVRUMRgwFgYDVQQDEw9mZWlkZS5lcmxhbmcubm8xITAfBgkqhkiG9w0BCQEWEmFuZHJlYXNAdW5pbmV0dC5ubzAeFw0wNzA2MTUxMjAxMzVaFw0wNzA4MTQxMjAxMzVaMIGEMQswCQYDVQQGEwJOTzEYMBYGA1UECBMPQW5kcmVhcyBTb2xiZXJnMQwwCgYDVQQHEwNGb28xEDAOBgNVBAoTB1VOSU5FVFQxGDAWBgNVBAMTD2ZlaWRlLmVybGFuZy5ubzEhMB8GCSqGSIb3DQEJARYSYW5kcmVhc0B1bmluZXR0Lm5vMIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQDivbhR7P516x/S3BqKxupQe0LONoliupiBOesCO3SHbDrl3+q9IbfnfmE04rNuMcPsIxB161TdDpIesLCn7c8aPHISKOtPlAeTZSnb8QAu7aRjZq3+PbrP5uW3TcfCGPtKTytHOge/OlJbo078dVhXQ14d1EDwXJW1rRXuUt4C8QIDAQABMA0GCSqGSIb3DQEBBQUAA4GBACDVfp86HObqY+e8BUoWQ9+VMQx1ASDohBjwOsg2WykUqRXF+dLfcUH9dWR63CtZIKFDbStNomPnQz7nbK+onygwBspVEbnHuUihZq3ZUdmumQqCw4Uvs/1Uvq3orOo/WJVhTyvLgFVK2QarQ4/67OZfHd7R+POBXhophSMv1ZOo',

--- a/tests/settings/settings1.php
+++ b/tests/settings/settings1.php
@@ -1,23 +1,23 @@
 <?php
-    $settingsInfo = array (
+    $settingsInfo = array(
         'strict' => false,
         'debug' => false,
-        'sp' => array (
+        'sp' => array(
             'entityId' => 'http://stuff.com/endpoints/metadata.php',
-            'assertionConsumerService' => array (
+            'assertionConsumerService' => array(
                 'url' => 'http://stuff.com/endpoints/endpoints/acs.php',
             ),
-            'singleLogoutService' => array (
+            'singleLogoutService' => array(
                 'url' => 'http://stuff.com/endpoints/endpoints/sls.php',
             ),
             'NameIDFormat' => 'urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified',
         ),
-        'idp' => array (
+        'idp' => array(
             'entityId' => 'http://idp.example.com/',
-            'singleSignOnService' => array (
+            'singleSignOnService' => array(
                 'url' => 'http://idp.example.com/SSOService.php',
             ),
-            'singleLogoutService' => array (
+            'singleLogoutService' => array(
                 'url' => 'http://idp.example.com/SingleLogoutService.php',
             ),
             'x509cert' => 'MIICgTCCAeoCCQCbOlrWDdX7FTANBgkqhkiG9w0BAQUFADCBhDELMAkGA1UEBhMCTk8xGDAWBgNVBAgTD0FuZHJlYXMgU29sYmVyZzEMMAoGA1UEBxMDRm9vMRAwDgYDVQQKEwdVTklORVRUMRgwFgYDVQQDEw9mZWlkZS5lcmxhbmcubm8xITAfBgkqhkiG9w0BCQEWEmFuZHJlYXNAdW5pbmV0dC5ubzAeFw0wNzA2MTUxMjAxMzVaFw0wNzA4MTQxMjAxMzVaMIGEMQswCQYDVQQGEwJOTzEYMBYGA1UECBMPQW5kcmVhcyBTb2xiZXJnMQwwCgYDVQQHEwNGb28xEDAOBgNVBAoTB1VOSU5FVFQxGDAWBgNVBAMTD2ZlaWRlLmVybGFuZy5ubzEhMB8GCSqGSIb3DQEJARYSYW5kcmVhc0B1bmluZXR0Lm5vMIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQDivbhR7P516x/S3BqKxupQe0LONoliupiBOesCO3SHbDrl3+q9IbfnfmE04rNuMcPsIxB161TdDpIesLCn7c8aPHISKOtPlAeTZSnb8QAu7aRjZq3+PbrP5uW3TcfCGPtKTytHOge/OlJbo078dVhXQ14d1EDwXJW1rRXuUt4C8QIDAQABMA0GCSqGSIb3DQEBBQUAA4GBACDVfp86HObqY+e8BUoWQ9+VMQx1ASDohBjwOsg2WykUqRXF+dLfcUH9dWR63CtZIKFDbStNomPnQz7nbK+onygwBspVEbnHuUihZq3ZUdmumQqCw4Uvs/1Uvq3orOo/WJVhTyvLgFVK2QarQ4/67OZfHd7R+POBXhophSMv1ZOo',
@@ -26,23 +26,23 @@
             'requests' => true,
             'responses' => true
         ),
-        'security' => array (
+        'security' => array(
             'authnRequestsSigned' => false,
             'wantAssertionsSigned' => false,
             'signMetadata' => false,
         ),
-        'contactPerson' => array (
-            'technical' => array (
+        'contactPerson' => array(
+            'technical' => array(
                 'givenName' => 'technical_name',
                 'emailAddress' => 'technical@example.com',
             ),
-            'support' => array (
+            'support' => array(
                 'givenName' => 'support_name',
                 'emailAddress' => 'support@example.com',
             ),
         ),
 
-        'organization' => array (
+        'organization' => array(
             'en-US' => array(
                 'name' => 'sp_test',
                 'displayname' => 'SP test',

--- a/tests/settings/settings2.php
+++ b/tests/settings/settings2.php
@@ -1,26 +1,26 @@
 <?php
 
-$settingsInfo = array (
+$settingsInfo = array(
     'strict' => false,
     'debug' => false,
-    'sp' => array (
+    'sp' => array(
         'entityId' => 'http://stuff.com/endpoints/metadata.php',
-        'assertionConsumerService' => array (
+        'assertionConsumerService' => array(
             'url' => 'http://stuff.com/endpoints/endpoints/acs.php',
         ),
-        'singleLogoutService' => array (
+        'singleLogoutService' => array(
             'url' => 'http://stuff.com/endpoints/endpoints/sls.php',
         ),
         'NameIDFormat' => 'urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified',
         'privateKey' => 'MIICXgIBAAKBgQDivbhR7P516x/S3BqKxupQe0LONoliupiBOesCO3SHbDrl3+q9IbfnfmE04rNuMcPsIxB161TdDpIesLCn7c8aPHISKOtPlAeTZSnb8QAu7aRjZq3+PbrP5uW3TcfCGPtKTytHOge/OlJbo078dVhXQ14d1EDwXJW1rRXuUt4C8QIDAQABAoGAD4/Z4LWVWV6D1qMIp1Gzr0ZmdWTE1SPdZ7Ej8glGnCzPdguCPuzbhGXmIg0VJ5D+02wsqws1zd48JSMXXM8zkYZVwQYIPUsNn5FetQpwxDIMPmhHg+QNBgwOnk8JK2sIjjLPL7qY7Itv7LT7Gvm5qSOkZ33RCgXcgz+okEIQMYkCQQDzbTOyDL0c5WQV6A2k06T/azdhUdGXF9C0+WkWSfNaovmTgRXh1G+jMlr82Snz4p4/STt7P/XtyWzF3pkVgZr3AkEA7nPjXwHlttNEMo6AtxHd47nizK2NUN803ElIUT8P9KSCoERmSXq66PDekGNic4ldpsSvOeYCk8MAYoDBy9kvVwJBAMLgX4xg6lzhv7hR5+pWjTb1rIY6rCHbrPfU264+UZXz9v2BT/VUznLF81WMvStD9xAPHpFS6R0OLghSZhdzhI0CQQDL8Duvfxzrn4b9QlmduV8wLERoT6rEVxKLsPVz316TGrxJvBZLk/cV0SRZE1cZf4ukXSWMfEcJ/0Zt+LdG1CqjAkEAqwLSglJ9Dy3HpgMz4vAAyZWzAxvyA1zW0no9GOLcPQnYaNUN/Fy2SYtETXTb0CQ9X1rt8ffkFP7ya+5TC83aMg==',
         'x509cert' => 'MIICgTCCAeoCCQCbOlrWDdX7FTANBgkqhkiG9w0BAQUFADCBhDELMAkGA1UEBhMCTk8xGDAWBgNVBAgTD0FuZHJlYXMgU29sYmVyZzEMMAoGA1UEBxMDRm9vMRAwDgYDVQQKEwdVTklORVRUMRgwFgYDVQQDEw9mZWlkZS5lcmxhbmcubm8xITAfBgkqhkiG9w0BCQEWEmFuZHJlYXNAdW5pbmV0dC5ubzAeFw0wNzA2MTUxMjAxMzVaFw0wNzA4MTQxMjAxMzVaMIGEMQswCQYDVQQGEwJOTzEYMBYGA1UECBMPQW5kcmVhcyBTb2xiZXJnMQwwCgYDVQQHEwNGb28xEDAOBgNVBAoTB1VOSU5FVFQxGDAWBgNVBAMTD2ZlaWRlLmVybGFuZy5ubzEhMB8GCSqGSIb3DQEJARYSYW5kcmVhc0B1bmluZXR0Lm5vMIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQDivbhR7P516x/S3BqKxupQe0LONoliupiBOesCO3SHbDrl3+q9IbfnfmE04rNuMcPsIxB161TdDpIesLCn7c8aPHISKOtPlAeTZSnb8QAu7aRjZq3+PbrP5uW3TcfCGPtKTytHOge/OlJbo078dVhXQ14d1EDwXJW1rRXuUt4C8QIDAQABMA0GCSqGSIb3DQEBBQUAA4GBACDVfp86HObqY+e8BUoWQ9+VMQx1ASDohBjwOsg2WykUqRXF+dLfcUH9dWR63CtZIKFDbStNomPnQz7nbK+onygwBspVEbnHuUihZq3ZUdmumQqCw4Uvs/1Uvq3orOo/WJVhTyvLgFVK2QarQ4/67OZfHd7R+POBXhophSMv1ZOo'
     ),
-    'idp' => array (
+    'idp' => array(
         'entityId' => 'http://idp.example.com/',
-        'singleSignOnService' => array (
+        'singleSignOnService' => array(
             'url' => 'http://idp.example.com/SSOService.php',
         ),
-        'singleLogoutService' => array (
+        'singleLogoutService' => array(
             'url' => 'http://idp.example.com/SingleLogoutService.php',
         ),
         'x509cert' => 'MIICgTCCAeoCCQCbOlrWDdX7FTANBgkqhkiG9w0BAQUFADCBhDELMAkGA1UEBhMCTk8xGDAWBgNVBAgTD0FuZHJlYXMgU29sYmVyZzEMMAoGA1UEBxMDRm9vMRAwDgYDVQQKEwdVTklORVRUMRgwFgYDVQQDEw9mZWlkZS5lcmxhbmcubm8xITAfBgkqhkiG9w0BCQEWEmFuZHJlYXNAdW5pbmV0dC5ubzAeFw0wNzA2MTUxMjAxMzVaFw0wNzA4MTQxMjAxMzVaMIGEMQswCQYDVQQGEwJOTzEYMBYGA1UECBMPQW5kcmVhcyBTb2xiZXJnMQwwCgYDVQQHEwNGb28xEDAOBgNVBAoTB1VOSU5FVFQxGDAWBgNVBAMTD2ZlaWRlLmVybGFuZy5ubzEhMB8GCSqGSIb3DQEJARYSYW5kcmVhc0B1bmluZXR0Lm5vMIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQDivbhR7P516x/S3BqKxupQe0LONoliupiBOesCO3SHbDrl3+q9IbfnfmE04rNuMcPsIxB161TdDpIesLCn7c8aPHISKOtPlAeTZSnb8QAu7aRjZq3+PbrP5uW3TcfCGPtKTytHOge/OlJbo078dVhXQ14d1EDwXJW1rRXuUt4C8QIDAQABMA0GCSqGSIb3DQEBBQUAA4GBACDVfp86HObqY+e8BUoWQ9+VMQx1ASDohBjwOsg2WykUqRXF+dLfcUH9dWR63CtZIKFDbStNomPnQz7nbK+onygwBspVEbnHuUihZq3ZUdmumQqCw4Uvs/1Uvq3orOo/WJVhTyvLgFVK2QarQ4/67OZfHd7R+POBXhophSMv1ZOo',
@@ -29,23 +29,23 @@ $settingsInfo = array (
         'requests' => false,
         'responses' => false
     ),
-    'security' => array (
+    'security' => array(
         'authnRequestsSigned' => false,
         'wantAssertionsSigned' => false,
         'signMetadata' => false,
     ),
-    'contactPerson' => array (
-        'technical' => array (
+    'contactPerson' => array(
+        'technical' => array(
             'givenName' => 'technical_name',
             'emailAddress' => 'technical@example.com',
         ),
-        'support' => array (
+        'support' => array(
             'givenName' => 'support_name',
             'emailAddress' => 'support@example.com',
         ),
     ),
 
-    'organization' => array (
+    'organization' => array(
         'en-US' => array(
             'name' => 'sp_test',
             'displayname' => 'SP test',

--- a/tests/settings/settings3.php
+++ b/tests/settings/settings3.php
@@ -1,32 +1,32 @@
 <?php
-    $settingsInfo = array (
+    $settingsInfo = array(
         'strict' => false,
         'debug' => false,
-        'sp' => array (
+        'sp' => array(
             'entityId' => 'http://stuff.com/endpoints/metadata.php',
-            'assertionConsumerService' => array (
+            'assertionConsumerService' => array(
                 'url' => 'http://stuff.com/endpoints/endpoints/acs.php',
             ),
-            'singleLogoutService' => array (
+            'singleLogoutService' => array(
                 'url' => 'http://stuff.com/endpoints/endpoints/sls.php',
             ),
             'NameIDFormat' => 'urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified',
-            'attributeConsumingService' => array (
+            'attributeConsumingService' => array(
                 'serviceName' => 'Service Name',
                 'serviceDescription' => 'Service Description',
-                'requestedAttributes' => array (
-                    array (
+                'requestedAttributes' => array(
+                    array(
                         'nameFormat' => OneLogin\Saml2\Constants::ATTRNAME_FORMAT_URI,
                         'isRequired' => true,
                         'name' => 'Email',
                         'friendlyName' => 'Email'
                     ),
-                    array (
+                    array(
                         'nameFormat' => OneLogin\Saml2\Constants::ATTRNAME_FORMAT_URI,
                         'isRequired' => true,
                         'name' => 'FirstName'
                     ),
-                    array (
+                    array(
                         'nameFormat' => OneLogin\Saml2\Constants::ATTRNAME_FORMAT_URI,
                         'isRequired' => true,
                         'name' => 'LastName',
@@ -34,34 +34,34 @@
                 )
             )
         ),
-        'idp' => array (
+        'idp' => array(
             'entityId' => 'http://idp.example.com/',
-            'singleSignOnService' => array (
+            'singleSignOnService' => array(
                 'url' => 'http://idp.example.com/SSOService.php',
             ),
-            'singleLogoutService' => array (
+            'singleLogoutService' => array(
                 'url' => 'http://idp.example.com/SingleLogoutService.php',
             ),
             'x509cert' => 'MIICgTCCAeoCCQCbOlrWDdX7FTANBgkqhkiG9w0BAQUFADCBhDELMAkGA1UEBhMCTk8xGDAWBgNVBAgTD0FuZHJlYXMgU29sYmVyZzEMMAoGA1UEBxMDRm9vMRAwDgYDVQQKEwdVTklORVRUMRgwFgYDVQQDEw9mZWlkZS5lcmxhbmcubm8xITAfBgkqhkiG9w0BCQEWEmFuZHJlYXNAdW5pbmV0dC5ubzAeFw0wNzA2MTUxMjAxMzVaFw0wNzA4MTQxMjAxMzVaMIGEMQswCQYDVQQGEwJOTzEYMBYGA1UECBMPQW5kcmVhcyBTb2xiZXJnMQwwCgYDVQQHEwNGb28xEDAOBgNVBAoTB1VOSU5FVFQxGDAWBgNVBAMTD2ZlaWRlLmVybGFuZy5ubzEhMB8GCSqGSIb3DQEJARYSYW5kcmVhc0B1bmluZXR0Lm5vMIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQDivbhR7P516x/S3BqKxupQe0LONoliupiBOesCO3SHbDrl3+q9IbfnfmE04rNuMcPsIxB161TdDpIesLCn7c8aPHISKOtPlAeTZSnb8QAu7aRjZq3+PbrP5uW3TcfCGPtKTytHOge/OlJbo078dVhXQ14d1EDwXJW1rRXuUt4C8QIDAQABMA0GCSqGSIb3DQEBBQUAA4GBACDVfp86HObqY+e8BUoWQ9+VMQx1ASDohBjwOsg2WykUqRXF+dLfcUH9dWR63CtZIKFDbStNomPnQz7nbK+onygwBspVEbnHuUihZq3ZUdmumQqCw4Uvs/1Uvq3orOo/WJVhTyvLgFVK2QarQ4/67OZfHd7R+POBXhophSMv1ZOo',
         ),
 
-        'security' => array (
+        'security' => array(
             'authnRequestsSigned' => false,
             'wantAssertionsSigned' => false,
             'signMetadata' => false,
         ),
-        'contactPerson' => array (
-            'technical' => array (
+        'contactPerson' => array(
+            'technical' => array(
                 'givenName' => 'technical_name',
                 'emailAddress' => 'technical@example.com',
             ),
-            'support' => array (
+            'support' => array(
                 'givenName' => 'support_name',
                 'emailAddress' => 'support@example.com',
             ),
         ),
 
-        'organization' => array (
+        'organization' => array(
             'en-US' => array(
                 'name' => 'sp_test',
                 'displayname' => 'SP test',

--- a/tests/settings/settings4.php
+++ b/tests/settings/settings4.php
@@ -1,27 +1,27 @@
 <?php
-    $settingsInfo = array (
+    $settingsInfo = array(
         'strict' => false,
         'debug' => false,
-        'sp' => array (
+        'sp' => array(
             'entityId' => 'http://stuff.com/endpoints/metadata.php',
-            'assertionConsumerService' => array (
+            'assertionConsumerService' => array(
                 'url' => 'http://stuff.com/endpoints/endpoints/acs.php',
             ),
-            'singleLogoutService' => array (
+            'singleLogoutService' => array(
                 'url' => 'http://stuff.com/endpoints/endpoints/sls.php',
             ),
             'NameIDFormat' => 'urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified',
-            'attributeConsumingService' => array (
+            'attributeConsumingService' => array(
                 'serviceName' => 'Service Name',
                 'serviceDescription' => 'Service Description',
-                'requestedAttributes' => array (
-                    array (
+                'requestedAttributes' => array(
+                    array(
                         'nameFormat' => OneLogin\Saml2\Constants::ATTRNAME_FORMAT_BASIC,
                         'isRequired' => false,
                         'name' => 'userType',
                         'attributeValue' => array('userType', 'admin')
                     ),
-                    array (
+                    array(
                         'nameFormat' => OneLogin\Saml2\Constants::ATTRNAME_FORMAT_URI,
                         'isRequired' => true,
                         'name' => 'urn:oid:0.9.2342.19200300.100.1.1',
@@ -30,34 +30,34 @@
                 )
             )
         ),
-        'idp' => array (
+        'idp' => array(
             'entityId' => 'http://idp.example.com/',
-            'singleSignOnService' => array (
+            'singleSignOnService' => array(
                 'url' => 'http://idp.example.com/SSOService.php',
             ),
-            'singleLogoutService' => array (
+            'singleLogoutService' => array(
                 'url' => 'http://idp.example.com/SingleLogoutService.php',
             ),
             'x509cert' => 'MIICgTCCAeoCCQCbOlrWDdX7FTANBgkqhkiG9w0BAQUFADCBhDELMAkGA1UEBhMCTk8xGDAWBgNVBAgTD0FuZHJlYXMgU29sYmVyZzEMMAoGA1UEBxMDRm9vMRAwDgYDVQQKEwdVTklORVRUMRgwFgYDVQQDEw9mZWlkZS5lcmxhbmcubm8xITAfBgkqhkiG9w0BCQEWEmFuZHJlYXNAdW5pbmV0dC5ubzAeFw0wNzA2MTUxMjAxMzVaFw0wNzA4MTQxMjAxMzVaMIGEMQswCQYDVQQGEwJOTzEYMBYGA1UECBMPQW5kcmVhcyBTb2xiZXJnMQwwCgYDVQQHEwNGb28xEDAOBgNVBAoTB1VOSU5FVFQxGDAWBgNVBAMTD2ZlaWRlLmVybGFuZy5ubzEhMB8GCSqGSIb3DQEJARYSYW5kcmVhc0B1bmluZXR0Lm5vMIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQDivbhR7P516x/S3BqKxupQe0LONoliupiBOesCO3SHbDrl3+q9IbfnfmE04rNuMcPsIxB161TdDpIesLCn7c8aPHISKOtPlAeTZSnb8QAu7aRjZq3+PbrP5uW3TcfCGPtKTytHOge/OlJbo078dVhXQ14d1EDwXJW1rRXuUt4C8QIDAQABMA0GCSqGSIb3DQEBBQUAA4GBACDVfp86HObqY+e8BUoWQ9+VMQx1ASDohBjwOsg2WykUqRXF+dLfcUH9dWR63CtZIKFDbStNomPnQz7nbK+onygwBspVEbnHuUihZq3ZUdmumQqCw4Uvs/1Uvq3orOo/WJVhTyvLgFVK2QarQ4/67OZfHd7R+POBXhophSMv1ZOo',
         ),
 
-        'security' => array (
+        'security' => array(
             'authnRequestsSigned' => false,
             'wantAssertionsSigned' => false,
             'signMetadata' => false,
         ),
-        'contactPerson' => array (
-            'technical' => array (
+        'contactPerson' => array(
+            'technical' => array(
                 'givenName' => 'technical_name',
                 'emailAddress' => 'technical@example.com',
             ),
-            'support' => array (
+            'support' => array(
                 'givenName' => 'support_name',
                 'emailAddress' => 'support@example.com',
             ),
         ),
 
-        'organization' => array (
+        'organization' => array(
             'en-US' => array(
                 'name' => 'sp_test',
                 'displayname' => 'SP test',

--- a/tests/settings/settings5.php
+++ b/tests/settings/settings5.php
@@ -1,13 +1,13 @@
 <?php
-    $settingsInfo = array (
+    $settingsInfo = array(
         'strict' => false,
         'debug' => false,
-        'sp' => array (
+        'sp' => array(
             'entityId' => 'http://stuff.com/endpoints/metadata.php',
-            'assertionConsumerService' => array (
+            'assertionConsumerService' => array(
                 'url' => 'http://stuff.com/endpoints/endpoints/acs.php',
             ),
-            'singleLogoutService' => array (
+            'singleLogoutService' => array(
                 'url' => 'http://stuff.com/endpoints/endpoints/sls.php',
             ),
             'NameIDFormat' => 'urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified',
@@ -15,12 +15,12 @@
             'x509cert' => 'MIICgTCCAeoCCQCbOlrWDdX7FTANBgkqhkiG9w0BAQUFADCBhDELMAkGA1UEBhMCTk8xGDAWBgNVBAgTD0FuZHJlYXMgU29sYmVyZzEMMAoGA1UEBxMDRm9vMRAwDgYDVQQKEwdVTklORVRUMRgwFgYDVQQDEw9mZWlkZS5lcmxhbmcubm8xITAfBgkqhkiG9w0BCQEWEmFuZHJlYXNAdW5pbmV0dC5ubzAeFw0wNzA2MTUxMjAxMzVaFw0wNzA4MTQxMjAxMzVaMIGEMQswCQYDVQQGEwJOTzEYMBYGA1UECBMPQW5kcmVhcyBTb2xiZXJnMQwwCgYDVQQHEwNGb28xEDAOBgNVBAoTB1VOSU5FVFQxGDAWBgNVBAMTD2ZlaWRlLmVybGFuZy5ubzEhMB8GCSqGSIb3DQEJARYSYW5kcmVhc0B1bmluZXR0Lm5vMIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQDivbhR7P516x/S3BqKxupQe0LONoliupiBOesCO3SHbDrl3+q9IbfnfmE04rNuMcPsIxB161TdDpIesLCn7c8aPHISKOtPlAeTZSnb8QAu7aRjZq3+PbrP5uW3TcfCGPtKTytHOge/OlJbo078dVhXQ14d1EDwXJW1rRXuUt4C8QIDAQABMA0GCSqGSIb3DQEBBQUAA4GBACDVfp86HObqY+e8BUoWQ9+VMQx1ASDohBjwOsg2WykUqRXF+dLfcUH9dWR63CtZIKFDbStNomPnQz7nbK+onygwBspVEbnHuUihZq3ZUdmumQqCw4Uvs/1Uvq3orOo/WJVhTyvLgFVK2QarQ4/67OZfHd7R+POBXhophSMv1ZOo',
             'x509certNew' => 'MIICVDCCAb2gAwIBAgIBADANBgkqhkiG9w0BAQ0FADBHMQswCQYDVQQGEwJ1czEQMA4GA1UECAwHZXhhbXBsZTEQMA4GA1UECgwHZXhhbXBsZTEUMBIGA1UEAwwLZXhhbXBsZS5jb20wHhcNMTcwNDA3MDgzMDAzWhcNMjcwNDA1MDgzMDAzWjBHMQswCQYDVQQGEwJ1czEQMA4GA1UECAwHZXhhbXBsZTEQMA4GA1UECgwHZXhhbXBsZTEUMBIGA1UEAwwLZXhhbXBsZS5jb20wgZ8wDQYJKoZIhvcNAQEBBQADgY0AMIGJAoGBAKhPS4/0azxbQekHHewQGKD7Pivr3CDpsrKxY3xlVanxj427OwzOb5KUVzsDEazumt6sZFY8HfidsjXY4EYA4ZzyL7ciIAR5vlAsIYN9nJ4AwVDnN/RjVwj+TN6BqWPLpVIpHc6Dl005HyE0zJnk1DZDn2tQVrIzbD3FhCp7YeotAgMBAAGjUDBOMB0GA1UdDgQWBBRYZx4thASfNvR/E7NsCF2IaZ7wIDAfBgNVHSMEGDAWgBRYZx4thASfNvR/E7NsCF2IaZ7wIDAMBgNVHRMEBTADAQH/MA0GCSqGSIb3DQEBDQUAA4GBACz4aobx9aG3kh+rNyrlgM3K6dYfnKG1/YH5sJCAOvg8kDr0fQAQifH8lFVWumKUMoAe0bFTfwWtp/VJ8MprrEJth6PFeZdczpuv+fpLcNj2VmNVJqvQYvS4m36OnBFh1QFZW8UrbFIfdtm2nuZ+twSKqfKwjLdqcoX0p39h7Uw/'
         ),
-        'idp' => array (
+        'idp' => array(
             'entityId' => 'http://idp.example.com/',
-            'singleSignOnService' => array (
+            'singleSignOnService' => array(
                 'url' => 'http://idp.example.com/SSOService.php',
             ),
-            'singleLogoutService' => array (
+            'singleLogoutService' => array(
                 'url' => 'http://idp.example.com/SingleLogoutService.php',
             ),
             'x509cert' => 'MIICgTCCAeoCCQCbOlrWDdX7FTANBgkqhkiG9w0BAQUFADCBhDELMAkGA1UEBhMCTk8xGDAWBgNVBAgTD0FuZHJlYXMgU29sYmVyZzEMMAoGA1UEBxMDRm9vMRAwDgYDVQQKEwdVTklORVRUMRgwFgYDVQQDEw9mZWlkZS5lcmxhbmcubm8xITAfBgkqhkiG9w0BCQEWEmFuZHJlYXNAdW5pbmV0dC5ubzAeFw0wNzA2MTUxMjAxMzVaFw0wNzA4MTQxMjAxMzVaMIGEMQswCQYDVQQGEwJOTzEYMBYGA1UECBMPQW5kcmVhcyBTb2xiZXJnMQwwCgYDVQQHEwNGb28xEDAOBgNVBAoTB1VOSU5FVFQxGDAWBgNVBAMTD2ZlaWRlLmVybGFuZy5ubzEhMB8GCSqGSIb3DQEJARYSYW5kcmVhc0B1bmluZXR0Lm5vMIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQDivbhR7P516x/S3BqKxupQe0LONoliupiBOesCO3SHbDrl3+q9IbfnfmE04rNuMcPsIxB161TdDpIesLCn7c8aPHISKOtPlAeTZSnb8QAu7aRjZq3+PbrP5uW3TcfCGPtKTytHOge/OlJbo078dVhXQ14d1EDwXJW1rRXuUt4C8QIDAQABMA0GCSqGSIb3DQEBBQUAA4GBACDVfp86HObqY+e8BUoWQ9+VMQx1ASDohBjwOsg2WykUqRXF+dLfcUH9dWR63CtZIKFDbStNomPnQz7nbK+onygwBspVEbnHuUihZq3ZUdmumQqCw4Uvs/1Uvq3orOo/WJVhTyvLgFVK2QarQ4/67OZfHd7R+POBXhophSMv1ZOo'
@@ -29,23 +29,23 @@
             'requests' => true,
             'responses' => true
         ),
-        'security' => array (
+        'security' => array(
             'authnRequestsSigned' => false,
             'wantAssertionsSigned' => false,
             'signMetadata' => false,
         ),
-        'contactPerson' => array (
-            'technical' => array (
+        'contactPerson' => array(
+            'technical' => array(
                 'givenName' => 'technical_name',
                 'emailAddress' => 'technical@example.com',
             ),
-            'support' => array (
+            'support' => array(
                 'givenName' => 'support_name',
                 'emailAddress' => 'support@example.com',
             ),
         ),
 
-        'organization' => array (
+        'organization' => array(
             'en-US' => array(
                 'name' => 'sp_test',
                 'displayname' => 'SP test',

--- a/tests/settings/settings6.php
+++ b/tests/settings/settings6.php
@@ -1,25 +1,25 @@
 <?php
-    $settingsInfo = array (
+    $settingsInfo = array(
         'strict' => false,
         'debug' => false,
-        'sp' => array (
+        'sp' => array(
             'entityId' => 'http://stuff.com/endpoints/metadata.php',
-            'assertionConsumerService' => array (
+            'assertionConsumerService' => array(
                 'url' => 'http://stuff.com/endpoints/endpoints/acs.php',
             ),
-            'singleLogoutService' => array (
+            'singleLogoutService' => array(
                 'url' => 'http://stuff.com/endpoints/endpoints/sls.php',
             ),
             'NameIDFormat' => 'urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified',
             'privateKey' => 'MIICXgIBAAKBgQDivbhR7P516x/S3BqKxupQe0LONoliupiBOesCO3SHbDrl3+q9IbfnfmE04rNuMcPsIxB161TdDpIesLCn7c8aPHISKOtPlAeTZSnb8QAu7aRjZq3+PbrP5uW3TcfCGPtKTytHOge/OlJbo078dVhXQ14d1EDwXJW1rRXuUt4C8QIDAQABAoGAD4/Z4LWVWV6D1qMIp1Gzr0ZmdWTE1SPdZ7Ej8glGnCzPdguCPuzbhGXmIg0VJ5D+02wsqws1zd48JSMXXM8zkYZVwQYIPUsNn5FetQpwxDIMPmhHg+QNBgwOnk8JK2sIjjLPL7qY7Itv7LT7Gvm5qSOkZ33RCgXcgz+okEIQMYkCQQDzbTOyDL0c5WQV6A2k06T/azdhUdGXF9C0+WkWSfNaovmTgRXh1G+jMlr82Snz4p4/STt7P/XtyWzF3pkVgZr3AkEA7nPjXwHlttNEMo6AtxHd47nizK2NUN803ElIUT8P9KSCoERmSXq66PDekGNic4ldpsSvOeYCk8MAYoDBy9kvVwJBAMLgX4xg6lzhv7hR5+pWjTb1rIY6rCHbrPfU264+UZXz9v2BT/VUznLF81WMvStD9xAPHpFS6R0OLghSZhdzhI0CQQDL8Duvfxzrn4b9QlmduV8wLERoT6rEVxKLsPVz316TGrxJvBZLk/cV0SRZE1cZf4ukXSWMfEcJ/0Zt+LdG1CqjAkEAqwLSglJ9Dy3HpgMz4vAAyZWzAxvyA1zW0no9GOLcPQnYaNUN/Fy2SYtETXTb0CQ9X1rt8ffkFP7ya+5TC83aMg==',
             'x509cert' => 'MIICgTCCAeoCCQCbOlrWDdX7FTANBgkqhkiG9w0BAQUFADCBhDELMAkGA1UEBhMCTk8xGDAWBgNVBAgTD0FuZHJlYXMgU29sYmVyZzEMMAoGA1UEBxMDRm9vMRAwDgYDVQQKEwdVTklORVRUMRgwFgYDVQQDEw9mZWlkZS5lcmxhbmcubm8xITAfBgkqhkiG9w0BCQEWEmFuZHJlYXNAdW5pbmV0dC5ubzAeFw0wNzA2MTUxMjAxMzVaFw0wNzA4MTQxMjAxMzVaMIGEMQswCQYDVQQGEwJOTzEYMBYGA1UECBMPQW5kcmVhcyBTb2xiZXJnMQwwCgYDVQQHEwNGb28xEDAOBgNVBAoTB1VOSU5FVFQxGDAWBgNVBAMTD2ZlaWRlLmVybGFuZy5ubzEhMB8GCSqGSIb3DQEJARYSYW5kcmVhc0B1bmluZXR0Lm5vMIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQDivbhR7P516x/S3BqKxupQe0LONoliupiBOesCO3SHbDrl3+q9IbfnfmE04rNuMcPsIxB161TdDpIesLCn7c8aPHISKOtPlAeTZSnb8QAu7aRjZq3+PbrP5uW3TcfCGPtKTytHOge/OlJbo078dVhXQ14d1EDwXJW1rRXuUt4C8QIDAQABMA0GCSqGSIb3DQEBBQUAA4GBACDVfp86HObqY+e8BUoWQ9+VMQx1ASDohBjwOsg2WykUqRXF+dLfcUH9dWR63CtZIKFDbStNomPnQz7nbK+onygwBspVEbnHuUihZq3ZUdmumQqCw4Uvs/1Uvq3orOo/WJVhTyvLgFVK2QarQ4/67OZfHd7R+POBXhophSMv1ZOo',
         ),
-        'idp' => array (
+        'idp' => array(
             'entityId' => 'http://idp.example.com/',
-            'singleSignOnService' => array (
+            'singleSignOnService' => array(
                 'url' => 'http://idp.example.com/SSOService.php',
             ),
-            'singleLogoutService' => array (
+            'singleLogoutService' => array(
                 'url' => 'http://idp.example.com/SingleLogoutService.php',
             ),
             'x509cert' => '',
@@ -38,23 +38,23 @@
             'requests' => true,
             'responses' => true
         ),
-        'security' => array (
+        'security' => array(
             'authnRequestsSigned' => false,
             'wantAssertionsSigned' => false,
             'signMetadata' => false,
         ),
-        'contactPerson' => array (
-            'technical' => array (
+        'contactPerson' => array(
+            'technical' => array(
                 'givenName' => 'technical_name',
                 'emailAddress' => 'technical@example.com',
             ),
-            'support' => array (
+            'support' => array(
                 'givenName' => 'support_name',
                 'emailAddress' => 'support@example.com',
             ),
         ),
 
-        'organization' => array (
+        'organization' => array(
             'en-US' => array(
                 'name' => 'sp_test',
                 'displayname' => 'SP test',

--- a/tests/settings/settings7.php
+++ b/tests/settings/settings7.php
@@ -1,21 +1,21 @@
 <?php
-    $settingsInfo = array (
-        'sp' => array (
+    $settingsInfo = array(
+        'sp' => array(
             'entityId' => 'http://stuff.com/endpoints/metadata.php',
-            'assertionConsumerService' => array (
+            'assertionConsumerService' => array(
                 'url' => 'http://stuff.com/endpoints/endpoints/acs.php',
             ),
-            'singleLogoutService' => array (
+            'singleLogoutService' => array(
                 'url' => 'http://stuff.com/endpoints/endpoints/sls.php',
             ),
             'NameIDFormat' => 'urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified',
         ),
-        'idp' => array (
+        'idp' => array(
             'entityId' => 'http://idp.example.com/',
-            'singleSignOnService' => array (
+            'singleSignOnService' => array(
                 'url' => 'http://idp.example.com/SSOService.php',
             ),
-            'singleLogoutService' => array (
+            'singleLogoutService' => array(
                 'url' => 'http://idp.example.com/SingleLogoutService.php',
             ),
             'x509cert' => 'MIICgTCCAeoCCQCbOlrWDdX7FTANBgkqhkiG9w0BAQUFADCBhDELMAkGA1UEBhMCTk8xGDAWBgNVBAgTD0FuZHJlYXMgU29sYmVyZzEMMAoGA1UEBxMDRm9vMRAwDgYDVQQKEwdVTklORVRUMRgwFgYDVQQDEw9mZWlkZS5lcmxhbmcubm8xITAfBgkqhkiG9w0BCQEWEmFuZHJlYXNAdW5pbmV0dC5ubzAeFw0wNzA2MTUxMjAxMzVaFw0wNzA4MTQxMjAxMzVaMIGEMQswCQYDVQQGEwJOTzEYMBYGA1UECBMPQW5kcmVhcyBTb2xiZXJnMQwwCgYDVQQHEwNGb28xEDAOBgNVBAoTB1VOSU5FVFQxGDAWBgNVBAMTD2ZlaWRlLmVybGFuZy5ubzEhMB8GCSqGSIb3DQEJARYSYW5kcmVhc0B1bmluZXR0Lm5vMIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQDivbhR7P516x/S3BqKxupQe0LONoliupiBOesCO3SHbDrl3+q9IbfnfmE04rNuMcPsIxB161TdDpIesLCn7c8aPHISKOtPlAeTZSnb8QAu7aRjZq3+PbrP5uW3TcfCGPtKTytHOge/OlJbo078dVhXQ14d1EDwXJW1rRXuUt4C8QIDAQABMA0GCSqGSIb3DQEBBQUAA4GBACDVfp86HObqY+e8BUoWQ9+VMQx1ASDohBjwOsg2WykUqRXF+dLfcUH9dWR63CtZIKFDbStNomPnQz7nbK+onygwBspVEbnHuUihZq3ZUdmumQqCw4Uvs/1Uvq3orOo/WJVhTyvLgFVK2QarQ4/67OZfHd7R+POBXhophSMv1ZOo',

--- a/tests/src/OneLogin/Saml2/AuthTest.php
+++ b/tests/src/OneLogin/Saml2/AuthTest.php
@@ -899,7 +899,7 @@ class AuthTest extends \PHPUnit\Framework\TestCase
     {
         try {
             $relayState = 'http://sp.example.com';
-            $parameters = array ('test1' => 'value1', 'test2' => 'value2');
+            $parameters = array('test1' => 'value1', 'test2' => 'value2');
 
             // The Header of the redirect produces an Exception
             $this->_auth->login($relayState, $parameters);
@@ -1286,7 +1286,7 @@ class AuthTest extends \PHPUnit\Framework\TestCase
     {
         try {
             $relayState = 'http://sp.example.com';
-            $parameters = array ('test1' => 'value1', 'test2' => 'value2');
+            $parameters = array('test1' => 'value1', 'test2' => 'value2');
 
             // The Header of the redirect produces an Exception
             $this->_auth->logout($relayState, $parameters);
@@ -1595,7 +1595,7 @@ class AuthTest extends \PHPUnit\Framework\TestCase
         $decodedLogoutResponse = gzinflate(base64_decode($parsedQuery['SAMLResponse']));
         $this->assertEquals($decodedLogoutResponse, $auth->getLastResponseXML());
 
-        $settingsInfo['compress'] = array (
+        $settingsInfo['compress'] = array(
             'responses' => true
         );
         $auth2 = new Auth($settingsInfo);
@@ -1604,7 +1604,7 @@ class AuthTest extends \PHPUnit\Framework\TestCase
         $decodedLogoutResponse2 = gzinflate(base64_decode($parsedQuery2['SAMLResponse']));
         $this->assertEquals($decodedLogoutResponse2, $auth2->getLastResponseXML());
 
-        $settingsInfo['compress'] = array (
+        $settingsInfo['compress'] = array(
             'responses' => false
         );
         $auth3 = new Auth($settingsInfo);

--- a/tests/src/OneLogin/Saml2/AuthnRequestTest.php
+++ b/tests/src/OneLogin/Saml2/AuthnRequestTest.php
@@ -82,7 +82,7 @@ class AuthnRequestTest extends \PHPUnit\Framework\TestCase
         $this->assertNotContains('<samlp:RequestedAuthnContext Comparison="exact">', $request3);
         $this->assertNotContains('<saml:AuthnContextClassRef>urn:oasis:names:tc:SAML:2.0:ac:classes:PasswordProtectedTransport</saml:AuthnContextClassRef>', $request3);
 
-        $settingsInfo['security']['requestedAuthnContext']= array ('urn:oasis:names:tc:SAML:2.0:ac:classes:Password', 'urn:oasis:names:tc:SAML:2.0:ac:classes:X509');
+        $settingsInfo['security']['requestedAuthnContext']= array('urn:oasis:names:tc:SAML:2.0:ac:classes:Password', 'urn:oasis:names:tc:SAML:2.0:ac:classes:X509');
         $settings4 = new Settings($settingsInfo);
         $authnRequest4 = new AuthnRequest($settings4);
         $encodedRequest4 = $authnRequest4->getRequest();
@@ -206,8 +206,8 @@ class AuthnRequestTest extends \PHPUnit\Framework\TestCase
         $settingsDir = TEST_ROOT .'/settings/';
         include $settingsDir.'settings1.php';
 
-        $settingsInfo['organization'] = array (
-            'es' => array (
+        $settingsInfo['organization'] = array(
+            'es' => array(
                 'name' => 'sp_prueba',
                 'displayname' => 'SP prueba',
                 'url' => 'http://sp.example.com'

--- a/tests/src/OneLogin/Saml2/IdPMetadataParserTest.php
+++ b/tests/src/OneLogin/Saml2/IdPMetadataParserTest.php
@@ -17,20 +17,20 @@ class IdPMetadataParserTest extends \PHPUnit\Framework\TestCase
      */
     public function testParseFileXML()
     {
-        $expectedInfo = array (
-            'idp' => array (
+        $expectedInfo = array(
+            'idp' => array(
                 'entityId' => 'https://app.onelogin.com/saml/metadata/645460',
-                'singleSignOnService' => array (
+                'singleSignOnService' => array(
                     'url' => 'https://example.onelogin.com/trust/saml2/http-redirect/sso/645460',
                     'binding' => 'urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect'
                 ),
-                'singleLogoutService' => array (
+                'singleLogoutService' => array(
                     'url' => 'https://example.onelogin.com/trust/saml2/http-redirect/slo/645460',
                     'binding' => 'urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect'
                 ),
                 'x509cert' => 'MIIEZTCCA02gAwIBAgIUPyy/A3bZAZ4m28PzEUUoT7RJhxIwDQYJKoZIhvcNAQEFBQAwcjELMAkGA1UEBhMCVVMxKzApBgNVBAoMIk9uZUxvZ2luIFRlc3QgKHNnYXJjaWEtdXMtcHJlcHJvZCkxFTATBgNVBAsMDE9uZUxvZ2luIElkUDEfMB0GA1UEAwwWT25lTG9naW4gQWNjb3VudCA4OTE0NjAeFw0xNjA4MDQyMjI5MzdaFw0yMTA4MDUyMjI5MzdaMHIxCzAJBgNVBAYTAlVTMSswKQYDVQQKDCJPbmVMb2dpbiBUZXN0IChzZ2FyY2lhLXVzLXByZXByb2QpMRUwEwYDVQQLDAxPbmVMb2dpbiBJZFAxHzAdBgNVBAMMFk9uZUxvZ2luIEFjY291bnQgODkxNDYwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDN6iqQGcLOCglNO42I2rkzE05UXSiMXT6c8ALThMMiaDw6qqzo3sd/tKK+NcNKWLIIC8TozWVyh5ykUiVZps+08xil7VsTU7E+wKu3kvmOsvw2wlRwtnoKZJwYhnr+RkBa+h1r3ZYUgXm1ZPeHMKj1g18KaWz9+MxYL6BhKqrOzfW/P2xxVRcFH7/pq+ZsDdgNzD2GD+apzY4MZyZj/N6BpBWJ0GlFsmtBegpbX3LBitJuFkk5L4/U/jjF1AJa3boBdCUVfATqO5G03H4XS1GySjBIRQXmlUF52rLjg6xCgWJ30/+t1X+IHLJeixiQ0vxyh6C4/usCEt94cgD1r8ADAgMBAAGjgfIwge8wDAYDVR0TAQH/BAIwADAdBgNVHQ4EFgQUPW0DcH0G3IwynWgi74co4wZ6n7gwga8GA1UdIwSBpzCBpIAUPW0DcH0G3IwynWgi74co4wZ6n7ihdqR0MHIxCzAJBgNVBAYTAlVTMSswKQYDVQQKDCJPbmVMb2dpbiBUZXN0IChzZ2FyY2lhLXVzLXByZXByb2QpMRUwEwYDVQQLDAxPbmVMb2dpbiBJZFAxHzAdBgNVBAMMFk9uZUxvZ2luIEFjY291bnQgODkxNDaCFD8svwN22QGeJtvD8xFFKE+0SYcSMA4GA1UdDwEB/wQEAwIHgDANBgkqhkiG9w0BAQUFAAOCAQEAQhB4q9jrycwbHrDSoYR1X4LFFzvJ9Us75wQquRHXpdyS9D6HUBXMGI6ahPicXCQrfLgN8vzMIiqZqfySXXv/8/dxe/X4UsWLYKYJHDJmxXD5EmWTa65chjkeP1oJAc8f3CKCpcP2lOBTthbnk2fEVAeLHR4xNdQO0VvGXWO9BliYPpkYqUIBvlm+Fg9mF7AM/Uagq2503XXIE1Lq//HON68P10vNMwLSKOtYLsoTiCnuIKGJqG37MsZVjQ1ZPRcO+LSLkq0i91gFxrOrVCrgztX4JQi5XkvEsYZGIXXjwHqxTVyt3adZWQO0LPxPqRiUqUzyhDhLo/xXNrHCu4VbMw=='
             ),
-            'sp' => array (
+            'sp' => array(
                 'NameIDFormat' => 'urn:oasis:names:tc:SAML:2.0:nameid-format:transient'
             )
         );
@@ -65,28 +65,28 @@ class IdPMetadataParserTest extends \PHPUnit\Framework\TestCase
      */
     public function testParseXML()
     {
-        $expectedInfo = array (
-            'idp' => array (
+        $expectedInfo = array(
+            'idp' => array(
                 'entityId' => 'https://idp.examle.com/saml/metadata',
-                'singleSignOnService' => array (
+                'singleSignOnService' => array(
                     'url' => 'https://idp.examle.com/saml/sso',
                     'binding' => 'urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect'
                 ),
-                'singleLogoutService' => array (
+                'singleLogoutService' => array(
                     'url' => 'https://idp.examle.com/saml/slo',
                     'binding' => 'urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect'
                 ),
-                'x509certMulti' => array (
-                    'signing' => array (
+                'x509certMulti' => array(
+                    'signing' => array(
                         0 => 'MIIEZTCCA02gAwIBAgIUPyy/A3bZAZ4m28PzEUUoT7RJhxIwDQYJKoZIhvcNAQEFBQAwcjELMAkGA1UEBhMCVVMxKzApBgNVBAoMIk9uZUxvZ2luIFRlc3QgKHNnYXJjaWEtdXMtcHJlcHJvZCkxFTATBgNVBAsMDE9uZUxvZ2luIElkUDEfMB0GA1UEAwwWT25lTG9naW4gQWNjb3VudCA4OTE0NjAeFw0xNjA4MDQyMjI5MzdaFw0yMTA4MDUyMjI5MzdaMHIxCzAJBgNVBAYTAlVTMSswKQYDVQQKDCJPbmVMb2dpbiBUZXN0IChzZ2FyY2lhLXVzLXByZXByb2QpMRUwEwYDVQQLDAxPbmVMb2dpbiBJZFAxHzAdBgNVBAMMFk9uZUxvZ2luIEFjY291bnQgODkxNDYwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDN6iqQGcLOCglNO42I2rkzE05UXSiMXT6c8ALThMMiaDw6qqzo3sd/tKK+NcNKWLIIC8TozWVyh5ykUiVZps+08xil7VsTU7E+wKu3kvmOsvw2wlRwtnoKZJwYhnr+RkBa+h1r3ZYUgXm1ZPeHMKj1g18KaWz9+MxYL6BhKqrOzfW/P2xxVRcFH7/pq+ZsDdgNzD2GD+apzY4MZyZj/N6BpBWJ0GlFsmtBegpbX3LBitJuFkk5L4/U/jjF1AJa3boBdCUVfATqO5G03H4XS1GySjBIRQXmlUF52rLjg6xCgWJ30/+t1X+IHLJeixiQ0vxyh6C4/usCEt94cgD1r8ADAgMBAAGjgfIwge8wDAYDVR0TAQH/BAIwADAdBgNVHQ4EFgQUPW0DcH0G3IwynWgi74co4wZ6n7gwga8GA1UdIwSBpzCBpIAUPW0DcH0G3IwynWgi74co4wZ6n7ihdqR0MHIxCzAJBgNVBAYTAlVTMSswKQYDVQQKDCJPbmVMb2dpbiBUZXN0IChzZ2FyY2lhLXVzLXByZXByb2QpMRUwEwYDVQQLDAxPbmVMb2dpbiBJZFAxHzAdBgNVBAMMFk9uZUxvZ2luIEFjY291bnQgODkxNDaCFD8svwN22QGeJtvD8xFFKE+0SYcSMA4GA1UdDwEB/wQEAwIHgDANBgkqhkiG9w0BAQUFAAOCAQEAQhB4q9jrycwbHrDSoYR1X4LFFzvJ9Us75wQquRHXpdyS9D6HUBXMGI6ahPicXCQrfLgN8vzMIiqZqfySXXv/8/dxe/X4UsWLYKYJHDJmxXD5EmWTa65chjkeP1oJAc8f3CKCpcP2lOBTthbnk2fEVAeLHR4xNdQO0VvGXWO9BliYPpkYqUIBvlm+Fg9mF7AM/Uagq2503XXIE1Lq//HON68P10vNMwLSKOtYLsoTiCnuIKGJqG37MsZVjQ1ZPRcO+LSLkq0i91gFxrOrVCrgztX4JQi5XkvEsYZGIXXjwHqxTVyt3adZWQO0LPxPqRiUqUzyhDhLo/xXNrHCu4VbMw==',
                         1 => 'MIICZDCCAc2gAwIBAgIBADANBgkqhkiG9w0BAQ0FADBPMQswCQYDVQQGEwJ1czEUMBIGA1UECAwLZXhhbXBsZS5jb20xFDASBgNVBAoMC2V4YW1wbGUuY29tMRQwEgYDVQQDDAtleGFtcGxlLmNvbTAeFw0xNzA0MTUxNjMzMThaFw0xODA0MTUxNjMzMThaME8xCzAJBgNVBAYTAnVzMRQwEgYDVQQIDAtleGFtcGxlLmNvbTEUMBIGA1UECgwLZXhhbXBsZS5jb20xFDASBgNVBAMMC2V4YW1wbGUuY29tMIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQC6GLkl5lDUZdHNDAojp5i24OoPlqrt5TGXJIPqAZYT1hQvJW5nv17MFDHrjmtEnmW4ACKEy0fAX80QWIcHunZSkbEGHb+NG/6oTi5RipXMvmHnfFnPJJ0AdtiLiPE478CV856gXekV4Xx5u3KrylcOgkpYsp0GMIQBDzleMUXlYQIDAQABo1AwTjAdBgNVHQ4EFgQUnP8vlYPGPL2n6ZzDYij2kMDC8wMwHwYDVR0jBBgwFoAUnP8vlYPGPL2n6ZzDYij2kMDC8wMwDAYDVR0TBAUwAwEB/zANBgkqhkiG9w0BAQ0FAAOBgQAlQGAl+b8Cpot1g+65lLLjVoY7APJPWLW0klKQNlMU0s4MU+71Y3ExUEOXDAZgKcFoavb1fEOGMwEf38NaJAy1e/l6VNuixXShffq20ymqHQxOG0q8ujeNkgZF9k6XDfn/QZ3AD0o/IrCT7UMc/0QsfgIjWYxwCvp2syApc5CYfQ=='
                     ),
-                    'encryption' => array (
+                    'encryption' => array(
                         0 => 'MIIEZTCCA02gAwIBAgIUPyy/A3bZAZ4m28PzEUUoT7RJhxIwDQYJKoZIhvcNAQEFBQAwcjELMAkGA1UEBhMCVVMxKzApBgNVBAoMIk9uZUxvZ2luIFRlc3QgKHNnYXJjaWEtdXMtcHJlcHJvZCkxFTATBgNVBAsMDE9uZUxvZ2luIElkUDEfMB0GA1UEAwwWT25lTG9naW4gQWNjb3VudCA4OTE0NjAeFw0xNjA4MDQyMjI5MzdaFw0yMTA4MDUyMjI5MzdaMHIxCzAJBgNVBAYTAlVTMSswKQYDVQQKDCJPbmVMb2dpbiBUZXN0IChzZ2FyY2lhLXVzLXByZXByb2QpMRUwEwYDVQQLDAxPbmVMb2dpbiBJZFAxHzAdBgNVBAMMFk9uZUxvZ2luIEFjY291bnQgODkxNDYwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDN6iqQGcLOCglNO42I2rkzE05UXSiMXT6c8ALThMMiaDw6qqzo3sd/tKK+NcNKWLIIC8TozWVyh5ykUiVZps+08xil7VsTU7E+wKu3kvmOsvw2wlRwtnoKZJwYhnr+RkBa+h1r3ZYUgXm1ZPeHMKj1g18KaWz9+MxYL6BhKqrOzfW/P2xxVRcFH7/pq+ZsDdgNzD2GD+apzY4MZyZj/N6BpBWJ0GlFsmtBegpbX3LBitJuFkk5L4/U/jjF1AJa3boBdCUVfATqO5G03H4XS1GySjBIRQXmlUF52rLjg6xCgWJ30/+t1X+IHLJeixiQ0vxyh6C4/usCEt94cgD1r8ADAgMBAAGjgfIwge8wDAYDVR0TAQH/BAIwADAdBgNVHQ4EFgQUPW0DcH0G3IwynWgi74co4wZ6n7gwga8GA1UdIwSBpzCBpIAUPW0DcH0G3IwynWgi74co4wZ6n7ihdqR0MHIxCzAJBgNVBAYTAlVTMSswKQYDVQQKDCJPbmVMb2dpbiBUZXN0IChzZ2FyY2lhLXVzLXByZXByb2QpMRUwEwYDVQQLDAxPbmVMb2dpbiBJZFAxHzAdBgNVBAMMFk9uZUxvZ2luIEFjY291bnQgODkxNDaCFD8svwN22QGeJtvD8xFFKE+0SYcSMA4GA1UdDwEB/wQEAwIHgDANBgkqhkiG9w0BAQUFAAOCAQEAQhB4q9jrycwbHrDSoYR1X4LFFzvJ9Us75wQquRHXpdyS9D6HUBXMGI6ahPicXCQrfLgN8vzMIiqZqfySXXv/8/dxe/X4UsWLYKYJHDJmxXD5EmWTa65chjkeP1oJAc8f3CKCpcP2lOBTthbnk2fEVAeLHR4xNdQO0VvGXWO9BliYPpkYqUIBvlm+Fg9mF7AM/Uagq2503XXIE1Lq//HON68P10vNMwLSKOtYLsoTiCnuIKGJqG37MsZVjQ1ZPRcO+LSLkq0i91gFxrOrVCrgztX4JQi5XkvEsYZGIXXjwHqxTVyt3adZWQO0LPxPqRiUqUzyhDhLo/xXNrHCu4VbMw=='
                     )
                 )
             ),
-            'sp' => array (
+            'sp' => array(
                 'NameIDFormat' => 'urn:oasis:names:tc:SAML:2.0:nameid-format:transient'
             )
         );
@@ -203,32 +203,32 @@ class IdPMetadataParserTest extends \PHPUnit\Framework\TestCase
     {
         $xml = file_get_contents(TEST_ROOT .'/data/metadata/idp/shib_metadata.xml');
 
-        $expectedInfo = array (
-            'idp' => array (
+        $expectedInfo = array(
+            'idp' => array(
                 'entityId' => 'https://si-saai.ualg.pt/idp/shibboleth',
-                'singleSignOnService' => array (
+                'singleSignOnService' => array(
                     'url' => 'https://si-saai.ualg.pt/idp/profile/SAML2/Redirect/SSO',
                     'binding' => 'urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect'
                 ),
                 'x509cert' => 'MIIDJzCCAg+gAwIBAgIUKuW5MuiehKHHdGjp+5rQDbXzx4IwDQYJKoZIhvcNAQEFBQAwGjEYMBYGA1UEAxMPc2ktc2FhaS51YWxnLnB0MB4XDTE2MDIwMTA5MTQwNFoXDTM2MDIwMTA5MTQwNFowGjEYMBYGA1UEAxMPc2ktc2FhaS51YWxnLnB0MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEApN/x2BG+tpJBXU+bPSReXt1V+kaSoH1zAbA62ckYhHM6VqlzrqCD5ZCErMt5ysc9jpvJZ9umze1hXRaIYbGHCc3ADfBgrXoedBO7P10psRAuZqXOzvBwD7Dkb25KHTo/si3ZFB5VMUAMzHdxNWlOyhkOOS++hY5sq21iTGy5qDxsFBmHxGFv0oZYMgB6ZFWwScX1GyD6YpnbqBrlvdzmCmtBmGxyVV/ReyY5dK03bbDiF5Hf2mQR24ORQ5VrsbwlRyPtjVcWSilEJOB0PVOoixewA07RBzCQTeGeC3trM9ZobVuOavDxGN6rxzWnhe0DE2+sTqARxsKOY5kgMkM4kwIDAQABo2UwYzBCBgNVHREEOzA5gg9zaS1zYWFpLnVhbGcucHSGJmh0dHBzOi8vc2ktc2FhaS51YWxnLnB0L2lkcC9zaGliYm9sZXRoMB0GA1UdDgQWBBTfBNAJjRTcPNuPowmLQ3a0hqaSKTANBgkqhkiG9w0BAQUFAAOCAQEAkP4lZzeVslQLxLFZWCVVcNh9LuGgsGuiVru8GUH63zNrrzwAyhlSXyXU+61Yn1MxFnx+Bn2zf9qG1UMmf6FFFyxYFCHN1iuo6P0DIkJgpvLo+qoRbYJxB552ZFeF/g8AvhUU910LFLQOHJzrfsrF9hJM2gAinZDbmjY7IsP1f9iLm5aP6tCSszjkEbWzsnweQMBlteNa/2m9Ncfb4TpRwvcViCW77uv/13bbYB4F4pTr6fVxqORhM7HSJYn6WkgZczGbCFUMaIfTxKSF9v7/bpHnbXIP8YekuHRId7rJxQiwaGni69uLUvfjTo4cRrDa6daZo2Ff1LlKlfjTN4ANRA=='
             ),
-            'sp' => array (
+            'sp' => array(
                 'NameIDFormat' => 'urn:mace:shibboleth:1.0:nameIdentifier'
             )
         );
         $idpInfo = IdPMetadataParser::parseXML($xml);
         $this->assertEquals($expectedInfo, $idpInfo);
 
-        $expectedInfo2 = array (
-            'idp' => array (
+        $expectedInfo2 = array(
+            'idp' => array(
                 'entityId' => 'https://idp.fccn.pt/idp/shibboleth',
-                'singleSignOnService' => array (
+                'singleSignOnService' => array(
                     'url' => 'https://idp.fccn.pt/idp/profile/SAML2/Redirect/SSO',
                     'binding' => 'urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect'
                 ),
                 'x509cert' => 'MIIDFzCCAf+gAwIBAgIUGjtxtRHoicZCdPTxK6N9BrR1vZ8wDQYJKoZIhvcNAQEFBQAwFjEUMBIGA1UEAxMLaWRwLmZjY24ucHQwHhcNMTExMjE1MTUzOTExWhcNMzExMjE1MTUzOTExWjAWMRQwEgYDVQQDEwtpZHAuZmNjbi5wdDCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAMk7r9by+CMZzGA/003Hjz08jJ9JrtfEQYOLVeh3CaMM3vAfwg5BljE+c7/fBs0teQRcnkx8oEGwGuBUV91qN5CIwRRgraXg2Xl5NDd+E76ebKWuOYqsB07V99esvRWwGMhAJrjd2Lc3u/th+8PNBfeXJOt49ZkC27uZ8ikfQauE0s9H+4i4c3bldrSVSuDq45yWr0wIHdox6dN/TjMk4kxSxyADmb/Ebp8N5n9v2l7Q9HFoaU2LnPJYyrbLrSepoFwdXgEYiu1pnrvbqT0SJ3vREctngTJ8MaL9dTLK2QaLN3cJkUby8254idNi8zPUHkvp2IFjuCcLc1k+ezdbc6kCAwEAAaNdMFswOgYDVR0RBDMwMYILaWRwLmZjY24ucHSGImh0dHBzOi8vaWRwLmZjY24ucHQvaWRwL3NoaWJib2xldGgwHQYDVR0OBBYEFAPVb6XSbR8AYJEn/xiLnVzx8KSoMA0GCSqGSIb3DQEBBQUAA4IBAQDF0YZ3v7xshyEUHIRxc8c2jM2cJOUBRj7aOqnJvOnK7FI/AaSGqtEMx9RJ+NHxr5sALx1/DBu1XPEdtuBfueL0C5ky4H8a78LRqH3x50oZto+Oq1DGhZr/kURJyAM9dzi8BYZx5K2wB9vvJO2DICmnla20DTlKPY8NMZwtFbwfMloQduMibLam1wEq+9o8TKYrw4C0pBGa8nY9gDjB1yzbT04VAuqctQL0+Sw+cXFDEk2JLbClBo4JbRU3T37aRSPJmLSx/lEQMBKP3cqlq+eig/e6thk3SA494XDUFlO6V+0XQF+uG5N6VkL0FX4oQt/9e14FaHZtwfb5uf02x6oO'
             ),
-            'sp' => array (
+            'sp' => array(
                 'NameIDFormat' => 'urn:mace:shibboleth:1.0:nameIdentifier'
             )
         );
@@ -247,32 +247,32 @@ class IdPMetadataParserTest extends \PHPUnit\Framework\TestCase
     {
         $xml = file_get_contents(TEST_ROOT .'/data/metadata/idp/shib_metadata.xml');
 
-        $expectedInfo = array (
-            'idp' => array (
+        $expectedInfo = array(
+            'idp' => array(
                 'entityId' => 'https://si-saai.ualg.pt/idp/shibboleth',
-                'singleSignOnService' => array (
+                'singleSignOnService' => array(
                     'url' => 'https://si-saai.ualg.pt/idp/profile/SAML2/Redirect/SSO',
                     'binding' => 'urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect'
                 ),
                 'x509cert' => 'MIIDJzCCAg+gAwIBAgIUKuW5MuiehKHHdGjp+5rQDbXzx4IwDQYJKoZIhvcNAQEFBQAwGjEYMBYGA1UEAxMPc2ktc2FhaS51YWxnLnB0MB4XDTE2MDIwMTA5MTQwNFoXDTM2MDIwMTA5MTQwNFowGjEYMBYGA1UEAxMPc2ktc2FhaS51YWxnLnB0MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEApN/x2BG+tpJBXU+bPSReXt1V+kaSoH1zAbA62ckYhHM6VqlzrqCD5ZCErMt5ysc9jpvJZ9umze1hXRaIYbGHCc3ADfBgrXoedBO7P10psRAuZqXOzvBwD7Dkb25KHTo/si3ZFB5VMUAMzHdxNWlOyhkOOS++hY5sq21iTGy5qDxsFBmHxGFv0oZYMgB6ZFWwScX1GyD6YpnbqBrlvdzmCmtBmGxyVV/ReyY5dK03bbDiF5Hf2mQR24ORQ5VrsbwlRyPtjVcWSilEJOB0PVOoixewA07RBzCQTeGeC3trM9ZobVuOavDxGN6rxzWnhe0DE2+sTqARxsKOY5kgMkM4kwIDAQABo2UwYzBCBgNVHREEOzA5gg9zaS1zYWFpLnVhbGcucHSGJmh0dHBzOi8vc2ktc2FhaS51YWxnLnB0L2lkcC9zaGliYm9sZXRoMB0GA1UdDgQWBBTfBNAJjRTcPNuPowmLQ3a0hqaSKTANBgkqhkiG9w0BAQUFAAOCAQEAkP4lZzeVslQLxLFZWCVVcNh9LuGgsGuiVru8GUH63zNrrzwAyhlSXyXU+61Yn1MxFnx+Bn2zf9qG1UMmf6FFFyxYFCHN1iuo6P0DIkJgpvLo+qoRbYJxB552ZFeF/g8AvhUU910LFLQOHJzrfsrF9hJM2gAinZDbmjY7IsP1f9iLm5aP6tCSszjkEbWzsnweQMBlteNa/2m9Ncfb4TpRwvcViCW77uv/13bbYB4F4pTr6fVxqORhM7HSJYn6WkgZczGbCFUMaIfTxKSF9v7/bpHnbXIP8YekuHRId7rJxQiwaGni69uLUvfjTo4cRrDa6daZo2Ff1LlKlfjTN4ANRA=='
             ),
-            'sp' => array (
+            'sp' => array(
                 'NameIDFormat' => 'urn:mace:shibboleth:1.0:nameIdentifier'
             )
         );
         $idpInfo = IdPMetadataParser::parseXML($xml);
         $this->assertEquals($expectedInfo, $idpInfo);
 
-        $expectedInfo2 = array (
-            'idp' => array (
+        $expectedInfo2 = array(
+            'idp' => array(
                 'entityId' => 'https://si-saai.ualg.pt/idp/shibboleth',
-                'singleSignOnService' => array (
+                'singleSignOnService' => array(
                     'url' => 'https://si-saai.ualg.pt/idp/profile/SAML2/Redirect/SSO',
                     'binding' => 'urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect'
                 ),
                 'x509cert' => 'MIIDJzCCAg+gAwIBAgIUKuW5MuiehKHHdGjp+5rQDbXzx4IwDQYJKoZIhvcNAQEFBQAwGjEYMBYGA1UEAxMPc2ktc2FhaS51YWxnLnB0MB4XDTE2MDIwMTA5MTQwNFoXDTM2MDIwMTA5MTQwNFowGjEYMBYGA1UEAxMPc2ktc2FhaS51YWxnLnB0MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEApN/x2BG+tpJBXU+bPSReXt1V+kaSoH1zAbA62ckYhHM6VqlzrqCD5ZCErMt5ysc9jpvJZ9umze1hXRaIYbGHCc3ADfBgrXoedBO7P10psRAuZqXOzvBwD7Dkb25KHTo/si3ZFB5VMUAMzHdxNWlOyhkOOS++hY5sq21iTGy5qDxsFBmHxGFv0oZYMgB6ZFWwScX1GyD6YpnbqBrlvdzmCmtBmGxyVV/ReyY5dK03bbDiF5Hf2mQR24ORQ5VrsbwlRyPtjVcWSilEJOB0PVOoixewA07RBzCQTeGeC3trM9ZobVuOavDxGN6rxzWnhe0DE2+sTqARxsKOY5kgMkM4kwIDAQABo2UwYzBCBgNVHREEOzA5gg9zaS1zYWFpLnVhbGcucHSGJmh0dHBzOi8vc2ktc2FhaS51YWxnLnB0L2lkcC9zaGliYm9sZXRoMB0GA1UdDgQWBBTfBNAJjRTcPNuPowmLQ3a0hqaSKTANBgkqhkiG9w0BAQUFAAOCAQEAkP4lZzeVslQLxLFZWCVVcNh9LuGgsGuiVru8GUH63zNrrzwAyhlSXyXU+61Yn1MxFnx+Bn2zf9qG1UMmf6FFFyxYFCHN1iuo6P0DIkJgpvLo+qoRbYJxB552ZFeF/g8AvhUU910LFLQOHJzrfsrF9hJM2gAinZDbmjY7IsP1f9iLm5aP6tCSszjkEbWzsnweQMBlteNa/2m9Ncfb4TpRwvcViCW77uv/13bbYB4F4pTr6fVxqORhM7HSJYn6WkgZczGbCFUMaIfTxKSF9v7/bpHnbXIP8YekuHRId7rJxQiwaGni69uLUvfjTo4cRrDa6daZo2Ff1LlKlfjTN4ANRA=='
             ),
-            'sp' => array (
+            'sp' => array(
                 'NameIDFormat' => 'urn:oasis:names:tc:SAML:2.0:nameid-format:transient'
             )
         );
@@ -410,31 +410,31 @@ class IdPMetadataParserTest extends \PHPUnit\Framework\TestCase
     public function testInjectIntoSettings()
     {
         $expectedMergedSettings = array(
-            'sp' => array (
+            'sp' => array(
                 'entityId' => 'http://stuff.com/endpoints/metadata.php',
-                'assertionConsumerService' => array (
+                'assertionConsumerService' => array(
                     'url' => 'http://stuff.com/endpoints/endpoints/acs.php'
                 ),
-                'singleLogoutService' => array (
+                'singleLogoutService' => array(
                     'url' => 'http://stuff.com/endpoints/endpoints/sls.php'
                 ),
                 'NameIDFormat' => 'urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress'
             ),
-            'idp' => array (
+            'idp' => array(
                 'entityId' => 'http://idp.adfs.example.com/adfs/services/trust',
-                'singleSignOnService' => array (
+                'singleSignOnService' => array(
                     'url' => 'https://idp.adfs.example.com/adfs/ls/',
                     'binding' => 'urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect'
                 ),
-                'singleLogoutService' => array (
+                'singleLogoutService' => array(
                     'url' => 'https://idp.adfs.example.com/adfs/ls/',
                     'binding' => 'urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect'
                 ),
-                'x509certMulti' => array (
-                    'signing' => array (
+                'x509certMulti' => array(
+                    'signing' => array(
                         0 => 'MIIC9jCCAd6gAwIBAgIQI/B8CLE676pCR2/QaKih9TANBgkqhkiG9w0BAQsFADA3MTUwMwYDVQQDEyxBREZTIFNpZ25pbmcgLSBsb2dpbnRlc3Qub3dlbnNib3JvaGVhbHRoLm9yZzAeFw0xNjEwMjUxNjI4MzhaFw0xNzEwMjUxNjI4MzhaMDcxNTAzBgNVBAMTLEFERlMgU2lnbmluZyAtIGxvZ2ludGVzdC5vd2Vuc2Jvcm9oZWFsdGgub3JnMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAjikmKRRVD5oK3fxm0xNfDqvWCujZIhtv2zeIwmoRKUAjo6KeUhauII4BHh5DclmbOFD4ruli3sNWGKgqVCX1AFW/p3m3/FtzeumFeZSmyfqeJEeOqAK5jAom/MfXxaQ85QHlGa0BTtdWdCuxhJz5G797o4s1Me/8QOQdmbkkwOHOVXRDW0QxBXvsRB1jPpIO+JvNcWFpvJrELccD0Fws91LH42j2C4gDNR8JLu5LrUGL6zAIq8NM7wfbwoax9n/0tIZKa6lo6szpXGqiMrDBJPpAqC5MSePyp5/SEX6jxwodQUGRgI5bKILQwOWDrkgfsK1MIeHfovtyqnDZj8e9VwIDAQABMA0GCSqGSIb3DQEBCwUAA4IBAQBKbK4qu7WTLYeQW7OcFAeWcT5D7ujo61QtPf+6eY8hpNntN8yF71vGm+5zdOjmw18igxUrf3W7dLk2wAogXK196WX34x9muorwmFK/HqmKuy0kWWzGcNzZHb0o4Md2Ux7QQVoHqD6dUSqUisOBs34ZPgT5R42LepJTGDEZSkvOxUv9V6fY5dYk8UaWbZ7MQAFi1CnOyybq2nVNjpuxWyJ6SsHQYKRhXa7XGurXFB2mlgcjVj9jxW0gO7djkgRD68b6PNpQmJkbKnkCtJg9YsSeOmuUjwgh4DlcIo5jZocKd5bnLbQ9XKJ3YQHRxFoZbP3BXKrfhVV3vqqzRxMwjZmK'
                     ),
-                    'encryption' => array (
+                    'encryption' => array(
                         0 => 'MIICZDCCAc2gAwIBAgIBADANBgkqhkiG9w0BAQ0FADBPMQswCQYDVQQGEwJ1czEUMBIGA1UECAwLZXhhbXBsZS5jb20xFDASBgNVBAoMC2V4YW1wbGUuY29tMRQwEgYDVQQDDAtleGFtcGxlLmNvbTAeFw0xNzA0MTUxMjI3NTFaFw0yNzA0MTMxMjI3NTFaME8xCzAJBgNVBAYTAnVzMRQwEgYDVQQIDAtleGFtcGxlLmNvbTEUMBIGA1UECgwLZXhhbXBsZS5jb20xFDASBgNVBAMMC2V4YW1wbGUuY29tMIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQCYtEZ7hGZiNp+NecbcQXosYl8TzVOdL44b3Nl+BxL26Bvnt8YNnE63xiQzo7xDdO6+1MWWO26mMxwMpooTToOJgrot9YhlIX1VHIUPbOEGczSmXzCCmMhS26vR/leoLNah8QqCF1UdCoNQejb0fDCy+Q1yEdMXYkBWsFGfDSHSSQIDAQABo1AwTjAdBgNVHQ4EFgQUT1g33aGN0f6BJPgpYbr1pHrMZrYwHwYDVR0jBBgwFoAUT1g33aGN0f6BJPgpYbr1pHrMZrYwDAYDVR0TBAUwAwEB/zANBgkqhkiG9w0BAQ0FAAOBgQB6233Ic9bb6OCMT6hE1mRzhoP+AbixeojtUuM1IUG4JI5YUGsjsym96VBw+/ciwDLuxNYg6ZWu++WxWNwF3LwVRZGQ8bDdxYldm6VorvIbps2tzyT5N32xgMAgzy/3SZf6YOihdotXJd5AZNVp/razVO17WrjsFvldAlKtk0SM7w=='
                     )
                 )

--- a/tests/src/OneLogin/Saml2/LogoutRequestTest.php
+++ b/tests/src/OneLogin/Saml2/LogoutRequestTest.php
@@ -322,7 +322,7 @@ class LogoutRequestTest extends \PHPUnit\Framework\TestCase
      */
     public function testGetNameIdData()
     {
-        $expectedNameIdData = array (
+        $expectedNameIdData = array(
             'Value' => 'ONELOGIN_1e442c129e1f822c8096086a1103c5ee2c7cae1c',
             'Format' => 'urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified',
             'SPNameQualifier' => 'http://idp.example.com/'
@@ -351,7 +351,7 @@ class LogoutRequestTest extends \PHPUnit\Framework\TestCase
         $key = $this->_settings->getSPkey();
         $nameIdData4 = LogoutRequest::getNameIdData($request2, $key);
 
-        $expectedNameIdData = array (
+        $expectedNameIdData = array(
             'Value' => 'ONELOGIN_9c86c4542ab9d6fce07f2f7fd335287b9b3cdf69',
             'Format' => 'urn:oasis:names:tc:SAML:2.0:nameid-format:emailAddress',
             'SPNameQualifier' => 'https://pitbulk.no-ip.org/newonelogin/demo1/metadata.php'
@@ -712,7 +712,7 @@ class LogoutRequestTest extends \PHPUnit\Framework\TestCase
         $currentURL = Utils::getSelfURLNoQuery();
 
         $this->_settings->setStrict(false);
-        $_GET = array (
+        $_GET = array(
             'SAMLRequest' => 'lVLBitswEP0Vo7tjeWzJtki8LIRCYLvbNksPewmyPc6K2pJqyXQ/v1LSQlroQi/DMJr33rwZbZ2cJysezNms/gt+X9H55G2etBOXlx1ZFy2MdMoJLWd0wvfieP/xQcCGCrsYb3ozkRvI+wjpHC5eGU2Sw35HTg3lA8hqZFwWFcMKsStpxbEsxoLXeQN9OdY1VAgk+YqLC8gdCUQB7tyKB+281D6UaF6mtEiBPudcABcMXkiyD26Ulv6CevXeOpFlVvlunb5ttEmV3ZjlnGn8YTRO5qx0NuBs8kzpAd829tXeucmR5NH4J/203I8el6gFRUqbFPJnyEV51Wq30by4TLW0/9ZyarYTxt4sBsjUYLMZvRykl1Fxm90SXVkfwx4P++T4KSafVzmpUcVJ/sfSrQZJPphllv79W8WKGtLx0ir8IrVTqD1pT2MH3QAMSs4KTvui71jeFFiwirOmprwPkYW063+5uRq4urHiiC4e8hCX3J5wqAEGaPpw9XB5JmkBdeDqSlkz6CmUXdl0Qae5kv2F/1384wu3PwE=',
             'RelayState' => '_1037fbc88ec82ce8e770b2bed1119747bb812a07e6',
             'SigAlg' => 'http://www.w3.org/2000/09/xmldsig#rsa-sha1',
@@ -812,7 +812,7 @@ class LogoutRequestTest extends \PHPUnit\Framework\TestCase
      */
     public function testIsValidSignUsingX509certMulti()
     {
-        $_GET = array (
+        $_GET = array(
             'SAMLRequest' => 'fZJNa+MwEIb/itHdiTz6sC0SQyEsBPoB27KHXoIsj7cGW3IlGfLzV7G7kN1DL2KYmeedmRcdgp7GWT26326JP/FzwRCz6zTaoNbKkSzeKqfDEJTVEwYVjXp9eHpUsKNq9i4640Zyh3xP6BDQx8FZkp1PR3KpqexAl72QmpUCS8SW01IiZz2TVVGD4X1VQYlAsl/oQyKPJAklPIQFzzZEbWNK0YLnlOVA3wqpQCoB7yQ7pWsGq+NKfcQ4q/0+xKXvd8ZNe7Td7AYbw10UxrCbP2aSPbv4Yl/8Qx/R3+SB5bTOoXiDQvFNvjnc7lXrIr75kh+6eYdXPc0jrkMO+/umjXhOtpxP2Q/nJx2/9+uWGbq8X1tV9NqGAW0kzaVvoe1AAJeCSWqYaUVRM2SilKKuqDTpFSlszdcK29RthVm9YriZebYdXpsLdhVAB7VJzif3haYMqqTVcl0JMBR4y+s2zak3sf/4v8l/vlHzBw==',
             'RelayState' => '_1037fbc88ec82ce8e770b2bed1119747bb812a07e6',
             'SigAlg' => 'http://www.w3.org/2000/09/xmldsig#rsa-sha1',

--- a/tests/src/OneLogin/Saml2/LogoutResponseTest.php
+++ b/tests/src/OneLogin/Saml2/LogoutResponseTest.php
@@ -280,7 +280,7 @@ class LogoutResponseTest extends \PHPUnit\Framework\TestCase
         $currentURL = Utils::getSelfURLNoQuery();
 
         $this->_settings->setStrict(false);
-        $_GET = array (
+        $_GET = array(
             'SAMLResponse' => 'fZJva8IwEMa/Ssl7TZrW/gnqGHMMwSlM8cXeyLU9NaxNQi9lfvxVZczB5ptwSe733MPdjQma2qmFPdjOvyE5awiDU1MbUpevCetaoyyQJmWgQVK+VOvH14WSQ6Fca70tbc1ukPsEEGHrtTUsmM8mbDfKUhnFci8gliGINI/yXIAAiYnsw6JIRgWWAKlkwRZb6skJ64V6nKjDuSEPxvdPIowHIhpIsQkTFaYqSt9ZMEPy2oC/UEfvHSnOnfZFV38MjR1oN7TtgRv8tAZre9CGV9jYkGtT4Wnoju6Bauprme/ebOyErZbPi9XLfLnDoohwhHGc5WVSVhjCKM6rBMpYQpWJrIizfZ4IZNPxuTPqYrmd/m+EdONqPOfy8yG5rhxv0EMFHs52xvxWaHyd3tqD7+j37clWGGyh7vD+POiSrdZdWSIR49NrhR9R/teGTL8A',
             'RelayState' => 'https://pitbulk.no-ip.org/newonelogin/demo1/index.php',
             'SigAlg' => 'http://www.w3.org/2000/09/xmldsig#rsa-sha1',
@@ -370,7 +370,7 @@ class LogoutResponseTest extends \PHPUnit\Framework\TestCase
      */
     public function testIsValidSignUsingX509certMulti()
     {
-        $_GET = array (
+        $_GET = array(
             'SAMLResponse' => 'fZHbasJAEIZfJey9ZrNZc1gSodRSBKtQxYveyGQz1kCyu2Q24OM3jS21UHo3p++f4Z+CoGud2th3O/hXJGcNYXDtWkNqapVs6I2yQA0pAx2S8lrtH142Ssy5cr31VtuW3SH/E0CEvW+sYcF6VbLTIktFLMWZgxQR8DSP85wDB4GJGMOqShYVaoBUsOCIPY1kyUahEScacG3Ig/FjiUdyxuOZ4IcoUVGq4vSNBSsk3xjwE3Xx3qkwJD+cz3NtuxBN7WxjPN1F1NLcXdwob77tONiS7bZPm93zenvCqopxgVJmuU50jREsZF4noKWAOuNZJbNznnBky+LTDDVd2S+/dje1m+MVOtfidEER3g8Vt2fsPfiBfmePtsbgCO2A/9tL07TaD1ojEQuXtw0/ouFfD19+AA==',
             'RelayState' => 'http://stuff.com/endpoints/endpoints/index.php',
             'SigAlg' => 'http://www.w3.org/2000/09/xmldsig#rsa-sha1',

--- a/tests/src/OneLogin/Saml2/ResponseTest.php
+++ b/tests/src/OneLogin/Saml2/ResponseTest.php
@@ -276,7 +276,7 @@ class ResponseTest extends \PHPUnit\Framework\TestCase
     {
         $xml = file_get_contents(TEST_ROOT . '/data/responses/response1.xml.base64');
         $response = new Response($this->_settings, $xml);
-        $expectedNameIdData = array (
+        $expectedNameIdData = array(
             'Value' => 'support@onelogin.com',
             'Format' => 'urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress',
             'NameQualifier' => 'https://test.example.com/saml/metadata'
@@ -286,7 +286,7 @@ class ResponseTest extends \PHPUnit\Framework\TestCase
 
         $xml2 = file_get_contents(TEST_ROOT . '/data/responses/response_encrypted_nameid.xml.base64');
         $response2 = new Response($this->_settings, $xml2);
-        $expectedNameIdData2 = array (
+        $expectedNameIdData2 = array(
             'Value' => '2de11defd199f8d5bb63f9b7deb265ba5c675c10',
             'Format' => 'urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified',
             'SPNameQualifier' => 'http://stuff.com/endpoints/metadata.php'
@@ -296,7 +296,7 @@ class ResponseTest extends \PHPUnit\Framework\TestCase
 
         $xml3 = file_get_contents(TEST_ROOT . '/data/responses/valid_encrypted_assertion.xml.base64');
         $response3 = new Response($this->_settings, $xml3);
-        $expectedNameIdData3 = array (
+        $expectedNameIdData3 = array(
             'Value' => '_68392312d490db6d355555cfbbd8ec95d746516f60',
             'Format' => 'urn:oasis:names:tc:SAML:2.0:nameid-format:transient',
             'SPNameQualifier' => 'http://stuff.com/endpoints/metadata.php'

--- a/tests/src/OneLogin/Saml2/SettingsTest.php
+++ b/tests/src/OneLogin/Saml2/SettingsTest.php
@@ -348,17 +348,17 @@ class SettingsTest extends \PHPUnit\Framework\TestCase
         include $settingsDir.'settings1.php';
 
         $settingsInfo['security']['signMetadata']['keyFileName'] = 'metadata.key';
-        $settingsInfo['organization'] = array (
+        $settingsInfo['organization'] = array(
             'en-US' => array(
                 'name' => 'miss_information'
             )
         );
 
-        $settingsInfo['contactPerson'] = array (
-            'support' => array (
+        $settingsInfo['contactPerson'] = array(
+            'support' => array(
                 'givenName' => 'support_name'
             ),
-            'auxiliar' => array (
+            'auxiliar' => array(
                 'givenName' => 'auxiliar_name',
                 'emailAddress' => 'auxiliar@example.com',
             ),
@@ -581,7 +581,7 @@ class SettingsTest extends \PHPUnit\Framework\TestCase
         if (!isset($settingsInfo['security'])) {
             $settingsInfo['security'] = array();
         }
-        $settingsInfo['security']['signMetadata'] = array ();
+        $settingsInfo['security']['signMetadata'] = array();
 
         try {
             $settings = new Settings($settingsInfo);
@@ -592,7 +592,7 @@ class SettingsTest extends \PHPUnit\Framework\TestCase
         }
 
 
-        $settingsInfo['security']['signMetadata'] = array (
+        $settingsInfo['security']['signMetadata'] = array(
             'keyFileName' => 'noexist.key',
             'certFileName' => 'sp.crt'
         );
@@ -605,7 +605,7 @@ class SettingsTest extends \PHPUnit\Framework\TestCase
             $this->assertContains('Private key file not found', $e->getMessage());
         }
 
-        $settingsInfo['security']['signMetadata'] = array (
+        $settingsInfo['security']['signMetadata'] = array(
             'keyFileName' => 'sp.key',
             'certFileName' => 'noexist.crt'
         );

--- a/tests/src/OneLogin/Saml2/UtilsTest.php
+++ b/tests/src/OneLogin/Saml2/UtilsTest.php
@@ -237,7 +237,7 @@ class UtilsTest extends \PHPUnit\Framework\TestCase
         }
 
         // Review parameter prefix
-        $parameters1 = array ('value1' => 'a');
+        $parameters1 = array('value1' => 'a');
 
         $targetUrl5 = Utils::redirect($url, $parameters1, true);
         $this->assertEquals("http://$hostname/example?value1=a", $targetUrl5);
@@ -246,19 +246,19 @@ class UtilsTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals("https://$hostname/example?test=true&value1=a", $targetUrl6);
 
         // Review parameters
-        $parameters2 = array (
+        $parameters2 = array(
             'alphavalue' => 'a',
-            'numvalue' => array ('1', '2'),
+            'numvalue' => array('1', '2'),
             'testing' => null,
         );
 
         $targetUrl7 = Utils::redirect($url, $parameters2, true);
         $this->assertEquals("http://$hostname/example?alphavalue=a&numvalue[]=1&numvalue[]=2&testing", $targetUrl7);
 
-        $parameters3 = array (
+        $parameters3 = array(
             'alphavalue' => 'a',
-            'emptynumvaluelist' => array (),
-            'numvaluelist' => array (''),
+            'emptynumvaluelist' => array(),
+            'numvaluelist' => array(''),
         );
 
         $targetUrl8 = Utils::redirect($url, $parameters3, true);


### PR DESCRIPTION
I noticed an inconsistant use of `array()` vs `array ()`.
The style that this project seems to follow is to put a space behind the array like it is an expression/keyword but since it is a constructor function and most styleguides and the official docs (http://php.net/manual/en/language.types.array.php) use `array()` (without a space) i moved everything over to that