### PR TITLE
Split redirect method into redirect and build url parts

### DIFF
--- a/demo2/index.php
+++ b/demo2/index.php
@@ -26,7 +26,7 @@ if (!isset($_SESSION['samlUserdata'])) {
 
     $idpData = $settings->getIdPData();
     $ssoUrl = $idpData['singleSignOnService']['url'];
-    $url = Utils::redirect($ssoUrl, $parameters, true);
+    $url = Utils::buildUrlWithQuery($ssoUrl, $parameters);
 
     header("Location: $url");
 } else {

--- a/demo2/slo.php
+++ b/demo2/slo.php
@@ -33,6 +33,6 @@ $samlRequest = $logoutRequest->getRequest();
 
 $parameters = array('SAMLRequest' => $samlRequest);
 
-$url = Utils::redirect($sloUrl, $parameters, true);
+$url = Utils::buildUrlWithQuery($sloUrl, $parameters);
 
 header("Location: $url");

--- a/src/Saml2/Auth.php
+++ b/src/Saml2/Auth.php
@@ -339,7 +339,10 @@ class Auth
             $url = $_REQUEST['RelayState'];
         }
 
-        return Utils::redirect($url, $parameters, $stay);
+        if ($stay) {
+            return Utils::buildUrlWithQuery($url, $parameters);
+        }
+        return Utils::redirect($url, $parameters);
     }
 
     /**

--- a/src/Saml2/Utils.php
+++ b/src/Saml2/Utils.php
@@ -272,17 +272,16 @@ class Utils
     }
 
     /**
-     * Executes a redirection to the provided url (or return the target url).
+     * Builds and verifies a url.
      *
-     * @param string $url        The target url
-     * @param array  $parameters Extra parameters to be passed as part of the url
-     * @param bool   $stay       True if we want to stay (returns the url string) False to redirect
+     * @param string $url        The base url
+     * @param array  $parameters Extra parameters to be appended to the url
      *
      * @return string|null $url
      *
      * @throws Error
      */
-    public static function redirect($url, array $parameters = array(), $stay = false)
+    public static function buildUrlWithQuery($url, array $parameters = array())
     {
         assert(is_string($url));
 
@@ -331,13 +330,24 @@ class Utils
             }
         }
 
-        if ($stay) {
-            return $url;
-        }
+        return $url;
+    }
 
+    /**
+     * Executes a redirection to the provided url.
+     *
+     * @param string $url        The target url
+     * @param array  $parameters Extra parameters to be passed as part of the url
+     *
+     * @return string|null $url
+     *
+     * @throws Error
+     */
+    public static function redirect($url, array $parameters = array())
+    {
         header('Pragma: no-cache');
         header('Cache-Control: no-cache, must-revalidate');
-        header('Location: ' . $url);
+        header('Location: ' . self::buildUrlWithQuery($url, $parameters));
         exit();
     }
 

--- a/tests/src/OneLogin/Saml2/AuthnRequestTest.php
+++ b/tests/src/OneLogin/Saml2/AuthnRequestTest.php
@@ -35,7 +35,7 @@ class AuthnRequestTest extends \PHPUnit\Framework\TestCase
     {
         $authnRequest = new AuthnRequest($this->_settings);
         $parameters = array('SAMLRequest' => $authnRequest->getRequest());
-        $authUrl = Utils::redirect('http://idp.example.com/SSOService.php', $parameters, true);
+        $authUrl = Utils::buildUrlWithQuery('http://idp.example.com/SSOService.php', $parameters);
         $this->assertRegExp('#^http://idp\.example\.com\/SSOService\.php\?SAMLRequest=#', $authUrl);
         parse_str(parse_url($authUrl, PHP_URL_QUERY), $exploded);
         // parse_url already urldecode de params so is not required.
@@ -219,7 +219,7 @@ class AuthnRequestTest extends \PHPUnit\Framework\TestCase
 
         $authnRequest = new AuthnRequest($settings);
         $parameters = array('SAMLRequest' => $authnRequest->getRequest());
-        $authUrl = Utils::redirect('http://idp.example.com/SSOService.php', $parameters, true);
+        $authUrl = Utils::buildUrlWithQuery('http://idp.example.com/SSOService.php', $parameters);
         $this->assertRegExp('#^http://idp\.example\.com\/SSOService\.php\?SAMLRequest=#', $authUrl);
         parse_str(parse_url($authUrl, PHP_URL_QUERY), $exploded);
         // parse_url already urldecode de params so is not required.

--- a/tests/src/OneLogin/Saml2/LogoutRequestTest.php
+++ b/tests/src/OneLogin/Saml2/LogoutRequestTest.php
@@ -46,7 +46,7 @@ class LogoutRequestTest extends \PHPUnit\Framework\TestCase
         $logoutRequest = new LogoutRequest($settings);
 
         $parameters = array('SAMLRequest' => $logoutRequest->getRequest());
-        $logoutUrl = Utils::redirect('http://idp.example.com/SingleLogoutService.php', $parameters, true);
+        $logoutUrl = Utils::buildUrlWithQuery('http://idp.example.com/SingleLogoutService.php', $parameters);
         $this->assertRegExp('#^http://idp\.example\.com\/SingleLogoutService\.php\?SAMLRequest=#', $logoutUrl);
         parse_str(parse_url($logoutUrl, PHP_URL_QUERY), $exploded);
         // parse_url already urldecode de params so is not required.
@@ -74,7 +74,7 @@ class LogoutRequestTest extends \PHPUnit\Framework\TestCase
         $logoutRequest = new LogoutRequest($settings, $encodedDeflatedRequest);
 
         $parameters = array('SAMLRequest' => $logoutRequest->getRequest());
-        $logoutUrl = Utils::redirect('http://idp.example.com/SingleLogoutService.php', $parameters, true);
+        $logoutUrl = Utils::buildUrlWithQuery('http://idp.example.com/SingleLogoutService.php', $parameters);
         $this->assertRegExp('#^http://idp\.example\.com\/SingleLogoutService\.php\?SAMLRequest=#', $logoutUrl);
         parse_str(parse_url($logoutUrl, PHP_URL_QUERY), $exploded);
         // parse_url already urldecode de params so is not required.
@@ -100,7 +100,7 @@ class LogoutRequestTest extends \PHPUnit\Framework\TestCase
         $logoutRequest = new LogoutRequest($settings, null, null, $sessionIndex);
 
         $parameters = array('SAMLRequest' => $logoutRequest->getRequest());
-        $logoutUrl = Utils::redirect('http://idp.example.com/SingleLogoutService.php', $parameters, true);
+        $logoutUrl = Utils::buildUrlWithQuery('http://idp.example.com/SingleLogoutService.php', $parameters);
         $this->assertRegExp('#^http://idp\.example\.com\/SingleLogoutService\.php\?SAMLRequest=#', $logoutUrl);
         parse_str(parse_url($logoutUrl, PHP_URL_QUERY), $exploded);
         // parse_url already urldecode de params so is not required.
@@ -131,7 +131,7 @@ class LogoutRequestTest extends \PHPUnit\Framework\TestCase
         $logoutRequest = new LogoutRequest($settings, null, $nameId, null, $nameIdFormat);
 
         $parameters = array('SAMLRequest' => $logoutRequest->getRequest());
-        $logoutUrl = Utils::redirect('http://idp.example.com/SingleLogoutService.php', $parameters, true);
+        $logoutUrl = Utils::buildUrlWithQuery('http://idp.example.com/SingleLogoutService.php', $parameters);
         $this->assertRegExp('#^http://idp\.example\.com\/SingleLogoutService\.php\?SAMLRequest=#', $logoutUrl);
         parse_str(parse_url($logoutUrl, PHP_URL_QUERY), $exploded);
         // parse_url already urldecode de params so is not required.
@@ -162,7 +162,7 @@ class LogoutRequestTest extends \PHPUnit\Framework\TestCase
         $settings = new Settings($settingsInfo);
         $logoutRequest = new LogoutRequest($settings, null, $nameId, null, null);
         $parameters = array('SAMLRequest' => $logoutRequest->getRequest());
-        $logoutUrl = Utils::redirect('http://idp.example.com/SingleLogoutService.php', $parameters, true);
+        $logoutUrl = Utils::buildUrlWithQuery('http://idp.example.com/SingleLogoutService.php', $parameters);
         $this->assertRegExp('#^http://idp\.example\.com\/SingleLogoutService\.php\?SAMLRequest=#', $logoutUrl);
         parse_str(parse_url($logoutUrl, PHP_URL_QUERY), $exploded);
         // parse_url already urldecode de params so is not required.
@@ -191,7 +191,7 @@ class LogoutRequestTest extends \PHPUnit\Framework\TestCase
         $settings = new Settings($settingsInfo);
         $logoutRequest = new LogoutRequest($settings, null, $nameId, null, null);
         $parameters = array('SAMLRequest' => $logoutRequest->getRequest());
-        $logoutUrl = Utils::redirect('http://idp.example.com/SingleLogoutService.php', $parameters, true);
+        $logoutUrl = Utils::buildUrlWithQuery('http://idp.example.com/SingleLogoutService.php', $parameters);
         $this->assertRegExp('#^http://idp\.example\.com\/SingleLogoutService\.php\?SAMLRequest=#', $logoutUrl);
         parse_str(parse_url($logoutUrl, PHP_URL_QUERY), $exploded);
         // parse_url already urldecode de params so is not required.
@@ -219,7 +219,7 @@ class LogoutRequestTest extends \PHPUnit\Framework\TestCase
         $settings = new Settings($settingsInfo);
         $logoutRequest = new LogoutRequest($settings, null, $nameId, null, $nameIdFormat, $nameIdNameQualifier);
         $parameters = array('SAMLRequest' => $logoutRequest->getRequest());
-        $logoutUrl = Utils::redirect('http://idp.example.com/SingleLogoutService.php', $parameters, true);
+        $logoutUrl = Utils::buildUrlWithQuery('http://idp.example.com/SingleLogoutService.php', $parameters);
         $this->assertRegExp('#^http://idp\.example\.com\/SingleLogoutService\.php\?SAMLRequest=#', $logoutUrl);
         parse_str(parse_url($logoutUrl, PHP_URL_QUERY), $exploded);
         // parse_url already urldecode de params so is not required.
@@ -245,7 +245,7 @@ class LogoutRequestTest extends \PHPUnit\Framework\TestCase
         $logoutRequest = new LogoutRequest($this->_settings);
 
         $parameters = array('SAMLRequest' => $logoutRequest->getRequest());
-        $logoutUrl = Utils::redirect('http://idp.example.com/SingleLogoutService.php', $parameters, true);
+        $logoutUrl = Utils::buildUrlWithQuery('http://idp.example.com/SingleLogoutService.php', $parameters);
         $this->assertRegExp('#^http://idp\.example\.com\/SingleLogoutService\.php\?SAMLRequest=#', $logoutUrl);
         parse_str(parse_url($logoutUrl, PHP_URL_QUERY), $exploded);
         // parse_url already urldecode de params so is not required.
@@ -273,7 +273,7 @@ class LogoutRequestTest extends \PHPUnit\Framework\TestCase
         $logoutRequest = new LogoutRequest($settings);
 
         $parameters = array('SAMLRequest' => $logoutRequest->getRequest());
-        $logoutUrl = Utils::redirect('http://idp.example.com/SingleLogoutService.php', $parameters, true);
+        $logoutUrl = Utils::buildUrlWithQuery('http://idp.example.com/SingleLogoutService.php', $parameters);
         $this->assertRegExp('#^http://idp\.example\.com\/SingleLogoutService\.php\?SAMLRequest=#', $logoutUrl);
         parse_str(parse_url($logoutUrl, PHP_URL_QUERY), $exploded);
         // parse_url already urldecode de params so is not required.

--- a/tests/src/OneLogin/Saml2/LogoutResponseTest.php
+++ b/tests/src/OneLogin/Saml2/LogoutResponseTest.php
@@ -53,7 +53,7 @@ class LogoutResponseTest extends \PHPUnit\Framework\TestCase
         $responseBuilder->build($inResponseTo);
         $parameters = array('SAMLResponse' => $responseBuilder->getResponse());
 
-        $logoutUrl = Utils::redirect('http://idp.example.com/SingleLogoutService.php', $parameters, true);
+        $logoutUrl = Utils::buildUrlWithQuery('http://idp.example.com/SingleLogoutService.php', $parameters);
 
         $this->assertRegExp('#^http://idp\.example\.com\/SingleLogoutService\.php\?SAMLResponse=#', $logoutUrl);
         parse_str(parse_url($logoutUrl, PHP_URL_QUERY), $exploded);

--- a/tests/src/OneLogin/Saml2/UtilsTest.php
+++ b/tests/src/OneLogin/Saml2/UtilsTest.php
@@ -207,19 +207,19 @@ class UtilsTest extends \PHPUnit\Framework\TestCase
     }
 
     /**
-     * Tests the redirect method of the Utils
+     * Tests the buildUrlWithQuery method of the Utils
      *
-     * @covers OneLogin\Saml2\Utils::redirect
+     * @covers OneLogin\Saml2\Utils::buildUrlWithQuery
      */
-    public function testRedirect()
+    public function testBuildUrlWithQuery()
     {
         // Check relative and absolute
         $hostname = Utils::getSelfHost();
         $url = "http://$hostname/example";
         $url2 = '/example';
 
-        $targetUrl = Utils::redirect($url, array(), true);
-        $targetUrl2 = Utils::redirect($url2, array(), true);
+        $targetUrl = Utils::buildUrlWithQuery($url, array());
+        $targetUrl2 = Utils::buildUrlWithQuery($url2, array());
 
         $this->assertEquals($targetUrl, $targetUrl2);
 
@@ -227,10 +227,10 @@ class UtilsTest extends \PHPUnit\Framework\TestCase
         $url3 = "https://$hostname/example?test=true";
         $url4 = "ftp://$hostname/example";
 
-        $targetUrl3 = Utils::redirect($url3, array(), true);
+        $targetUrl3 = Utils::buildUrlWithQuery($url3, array());
 
         try {
-            $targetUrl4 = Utils::redirect($url4, array(), true);
+            $targetUrl4 = Utils::buildUrlWithQuery($url4, array());
             $this->fail('Exception was not raised');
         } catch (Exception $e) {
             $this->assertContains('Redirect to invalid URL', $e->getMessage());
@@ -239,10 +239,10 @@ class UtilsTest extends \PHPUnit\Framework\TestCase
         // Review parameter prefix
         $parameters1 = array ('value1' => 'a');
 
-        $targetUrl5 = Utils::redirect($url, $parameters1, true);
+        $targetUrl5 = Utils::buildUrlWithQuery($url, $parameters1);
         $this->assertEquals("http://$hostname/example?value1=a", $targetUrl5);
 
-        $targetUrl6 = Utils::redirect($url3, $parameters1, true);
+        $targetUrl6 = Utils::buildUrlWithQuery($url3, $parameters1);
         $this->assertEquals("https://$hostname/example?test=true&value1=a", $targetUrl6);
 
         // Review parameters
@@ -252,7 +252,7 @@ class UtilsTest extends \PHPUnit\Framework\TestCase
             'testing' => null,
         );
 
-        $targetUrl7 = Utils::redirect($url, $parameters2, true);
+        $targetUrl7 = Utils::buildUrlWithQuery($url, $parameters2);
         $this->assertEquals("http://$hostname/example?alphavalue=a&numvalue[]=1&numvalue[]=2&testing", $targetUrl7);
 
         $parameters3 = array (
@@ -261,7 +261,7 @@ class UtilsTest extends \PHPUnit\Framework\TestCase
             'numvaluelist' => array (''),
         );
 
-        $targetUrl8 = Utils::redirect($url, $parameters3, true);
+        $targetUrl8 = Utils::buildUrlWithQuery($url, $parameters3);
         $this->assertEquals("http://$hostname/example?alphavalue=a&numvaluelist[]=", $targetUrl8);
     }
 


### PR DESCRIPTION
sort of kind of making utils redirect more [single responsibility](https://www.toptal.com/software/single-responsibility-principle) oriented.

Makes tests more explicit, in that the actual redirect is not tested but the url that is redirected to is.

Lifted up the `$stay` flag into the `Auth::redirectTo` method so that consumers shouldn't need to change.

In the future this way i'd become possible to refactor `Utils::redirect()` to only take a url and be overwriteable so it becomes easier/neater to integrate into frameworks (Laravel/Symphony).