### PR TITLE
Feature support: SLO ResponseLocation

### DIFF
--- a/README.md
+++ b/README.md
@@ -375,6 +375,9 @@ $settings = array (
         'singleLogoutService' => array (
             // URL Location of the IdP where SLO Request will be sent.
             'url' => '',
+            // URL location of the IdP where the SP will send the SLO Response (ResponseLocation)
+            // if not set, url for the SLO Request will be used
+            'responseUrl' => '',            
             // SAML protocol binding to be used when returning the <Response>
             // message. OneLogin Toolkit supports the HTTP-Redirect binding
             // only for this endpoint.

--- a/lib/Saml2/Auth.php
+++ b/lib/Saml2/Auth.php
@@ -588,7 +588,6 @@ class OneLogin_Saml2_Auth
      */
     public function getSLOResponseUrl()
     {
-        $url = null;
         $idpData = $this->_settings->getIdPData();
         if (isset($idpData['singleLogoutService']) && isset($idpData['singleLogoutService']['responseUrl'])) {
             return $idpData['singleLogoutService']['responseUrl'];

--- a/lib/Saml2/Auth.php
+++ b/lib/Saml2/Auth.php
@@ -285,7 +285,7 @@ class OneLogin_Saml2_Auth
                     $parameters['Signature'] = $signature;
                 }
 
-                return $this->redirectTo($this->getSLOurl(), $parameters, $stay);
+                return $this->redirectTo($this->getSLOResponseUrl(), $parameters, $stay);
             }
         } else {
             $this->_errors[] = 'invalid_binding';
@@ -579,6 +579,21 @@ class OneLogin_Saml2_Auth
             $url = $idpData['singleLogoutService']['url'];
         }
         return $url;
+    }
+
+    /**
+     * Gets the SLO response url.
+     *
+     * @return string|null The response url of the Single Logout Service
+     */
+    public function getSLOResponseUrl()
+    {
+        $url = null;
+        $idpData = $this->_settings->getIdPData();
+        if (isset($idpData['singleLogoutService']) && isset($idpData['singleLogoutService']['responseUrl'])) {
+            return $idpData['singleLogoutService']['responseUrl'];
+        }
+        return $this->getSLOurl();
     }
 
     /**

--- a/lib/Saml2/IdPMetadataParser.php
+++ b/lib/Saml2/IdPMetadataParser.php
@@ -140,6 +140,7 @@ class OneLogin_Saml2_IdPMetadataParser
                 if ($sloNodes->length > 0) {
                     $metadataInfo['idp']['singleLogoutService'] = array(
                         'url' => $sloNodes->item(0)->getAttribute('Location'),
+                        'responseUrl' => $sloNodes->item(0)->getAttribute('ResponseLocation'),
                         'binding' => $sloNodes->item(0)->getAttribute('Binding')
                     );
                 }

--- a/lib/Saml2/Settings.php
+++ b/lib/Saml2/Settings.php
@@ -531,6 +531,14 @@ class OneLogin_Saml2_Settings
                 $errors[] = 'idp_slo_url_invalid';
             }
 
+            if (isset($idp['singleLogoutService'])
+                && isset($idp['singleLogoutService']['responseUrl'])
+                && !empty($idp['singleLogoutService']['responseUrl'])
+                && !filter_var($idp['singleLogoutService']['responseUrl'], FILTER_VALIDATE_URL)
+            ) {
+                $errors[] = 'idp_slo_response_url_invalid';
+            }
+
             if (isset($settings['security'])) {
                 $security = $settings['security'];
 

--- a/settings_example.php
+++ b/settings_example.php
@@ -93,6 +93,9 @@ $settings = array (
         'singleLogoutService' => array (
             // URL Location of the IdP where the SP will send the SLO Request
             'url' => '',
+            // URL location of the IdP where the SP will send the SLO Response (ResponseLocation)
+            // if not set, url for the SLO Request will be used
+            'responseUrl' => '',
             // SAML protocol binding to be used when returning the <Response>
             // message.  Onelogin Toolkit supports for this endpoint the
             // HTTP-Redirect binding only

--- a/tests/data/metadata/idp/metadata.xml
+++ b/tests/data/metadata/idp/metadata.xml
@@ -68,7 +68,7 @@ WQO0LPxPqRiUqUzyhDhLo/xXNrHCu4VbMw==</ds:X509Certificate>
         </ds:X509Data>
       </ds:KeyInfo>
     </KeyDescriptor>
-    <SingleLogoutService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect" Location="https://idp.examle.com/saml/slo"/>    
+    <SingleLogoutService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect" Location="https://idp.examle.com/saml/slo" ResponseLocation="https://idp.examle.com/saml/slr"/>
     <NameIDFormat>urn:oasis:names:tc:SAML:2.0:nameid-format:transient</NameIDFormat>
     <SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect" Location="https://idp.examle.com/saml/sso"/>
   </IDPSSODescriptor>

--- a/tests/settings/settings1.php
+++ b/tests/settings/settings1.php
@@ -19,6 +19,7 @@
             ),
             'singleLogoutService' => array (
                 'url' => 'http://idp.example.com/SingleLogoutService.php',
+                'responseUrl' => 'http://idp.example.com/SingleLogoutServiceResponse.php',
             ),
             'x509cert' => 'MIICgTCCAeoCCQCbOlrWDdX7FTANBgkqhkiG9w0BAQUFADCBhDELMAkGA1UEBhMCTk8xGDAWBgNVBAgTD0FuZHJlYXMgU29sYmVyZzEMMAoGA1UEBxMDRm9vMRAwDgYDVQQKEwdVTklORVRUMRgwFgYDVQQDEw9mZWlkZS5lcmxhbmcubm8xITAfBgkqhkiG9w0BCQEWEmFuZHJlYXNAdW5pbmV0dC5ubzAeFw0wNzA2MTUxMjAxMzVaFw0wNzA4MTQxMjAxMzVaMIGEMQswCQYDVQQGEwJOTzEYMBYGA1UECBMPQW5kcmVhcyBTb2xiZXJnMQwwCgYDVQQHEwNGb28xEDAOBgNVBAoTB1VOSU5FVFQxGDAWBgNVBAMTD2ZlaWRlLmVybGFuZy5ubzEhMB8GCSqGSIb3DQEJARYSYW5kcmVhc0B1bmluZXR0Lm5vMIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQDivbhR7P516x/S3BqKxupQe0LONoliupiBOesCO3SHbDrl3+q9IbfnfmE04rNuMcPsIxB161TdDpIesLCn7c8aPHISKOtPlAeTZSnb8QAu7aRjZq3+PbrP5uW3TcfCGPtKTytHOge/OlJbo078dVhXQ14d1EDwXJW1rRXuUt4C8QIDAQABMA0GCSqGSIb3DQEBBQUAA4GBACDVfp86HObqY+e8BUoWQ9+VMQx1ASDohBjwOsg2WykUqRXF+dLfcUH9dWR63CtZIKFDbStNomPnQz7nbK+onygwBspVEbnHuUihZq3ZUdmumQqCw4Uvs/1Uvq3orOo/WJVhTyvLgFVK2QarQ4/67OZfHd7R+POBXhophSMv1ZOo',
         ),

--- a/tests/src/OneLogin/Saml2/AuthTest.php
+++ b/tests/src/OneLogin/Saml2/AuthTest.php
@@ -80,6 +80,17 @@ class OneLogin_Saml2_AuthTest extends PHPUnit_Framework_TestCase
     }
 
     /**
+     * Tests the getSLOResponseUrl method of the OneLogin_Saml2_Auth class
+     *
+     * @covers OneLogin_Saml2_Auth::getSLOurl
+     */
+    public function testGetSLOResponseUrl()
+    {
+        $sloResponseUrl = $this->_settingsInfo['idp']['singleLogoutService']['responseUrl'];
+        $this->assertEquals($this->_auth->getSLOResponseUrl(), $sloResponseUrl);
+    }
+
+    /**
     * Tests the processResponse method of the OneLogin_Saml2_Auth class
     * Case No Response, An exception is throw
     *
@@ -548,8 +559,8 @@ class OneLogin_Saml2_AuthTest extends PHPUnit_Framework_TestCase
             $parsedQuery = getParamsFromUrl($targetUrl);
 
             $this->assertEmpty($this->_auth->getErrors());
-            $sloUrl = $this->_settingsInfo['idp']['singleLogoutService']['url'];
-            $this->assertContains($sloUrl, $targetUrl);
+            $sloResponseUrl = $this->_settingsInfo['idp']['singleLogoutService']['responseUrl'];
+            $this->assertContains($sloResponseUrl, $targetUrl);
             $this->assertArrayHasKey('SAMLResponse', $parsedQuery);
             $this->assertArrayNotHasKey('RelayState', $parsedQuery);
         }
@@ -570,8 +581,8 @@ class OneLogin_Saml2_AuthTest extends PHPUnit_Framework_TestCase
             $parsedQuery = getParamsFromUrl($targetUrl);
 
             $this->assertEmpty($this->_auth->getErrors());
-            $sloUrl = $this->_settingsInfo['idp']['singleLogoutService']['url'];
-            $this->assertContains($sloUrl, $targetUrl);
+            $sloResponseUrl = $this->_settingsInfo['idp']['singleLogoutService']['responseUrl'];
+            $this->assertContains($sloResponseUrl, $targetUrl);
             $this->assertArrayHasKey('SAMLResponse', $parsedQuery);
             $this->assertArrayNotHasKey('RelayState', $parsedQuery);
         }
@@ -636,8 +647,8 @@ class OneLogin_Saml2_AuthTest extends PHPUnit_Framework_TestCase
             $targetUrl = getUrlFromRedirect($trace);
             $parsedQuery = getParamsFromUrl($targetUrl);
 
-            $sloUrl = $this->_settingsInfo['idp']['singleLogoutService']['url'];
-            $this->assertContains($sloUrl, $targetUrl);
+            $sloResponseUrl = $this->_settingsInfo['idp']['singleLogoutService']['responseUrl'];
+            $this->assertContains($sloResponseUrl, $targetUrl);
             $this->assertArrayHasKey('SAMLResponse', $parsedQuery);
             $this->assertArrayNotHasKey('RelayState', $parsedQuery);
 
@@ -657,8 +668,8 @@ class OneLogin_Saml2_AuthTest extends PHPUnit_Framework_TestCase
             $targetUrl = getUrlFromRedirect($trace);
             $parsedQuery = getParamsFromUrl($targetUrl);
 
-            $sloUrl = $this->_settingsInfo['idp']['singleLogoutService']['url'];
-            $this->assertContains($sloUrl, $targetUrl);
+            $sloResponseUrl = $this->_settingsInfo['idp']['singleLogoutService']['responseUrl'];
+            $this->assertContains($sloResponseUrl, $targetUrl);
             $this->assertArrayHasKey('SAMLResponse', $parsedQuery);
             $this->assertArrayNotHasKey('RelayState', $parsedQuery);
 

--- a/tests/src/OneLogin/Saml2/IdPMetadataParserTest.php
+++ b/tests/src/OneLogin/Saml2/IdPMetadataParserTest.php
@@ -21,6 +21,7 @@ class OneLogin_Saml2_IdPMetadataParserTest extends PHPUnit_Framework_TestCase
                 ),
                 'singleLogoutService' => array (
                     'url' => 'https://example.onelogin.com/trust/saml2/http-redirect/slo/645460',
+                    'responseUrl' => '',
                     'binding' => 'urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect'
                 ),
                 'x509cert' => 'MIIEZTCCA02gAwIBAgIUPyy/A3bZAZ4m28PzEUUoT7RJhxIwDQYJKoZIhvcNAQEFBQAwcjELMAkGA1UEBhMCVVMxKzApBgNVBAoMIk9uZUxvZ2luIFRlc3QgKHNnYXJjaWEtdXMtcHJlcHJvZCkxFTATBgNVBAsMDE9uZUxvZ2luIElkUDEfMB0GA1UEAwwWT25lTG9naW4gQWNjb3VudCA4OTE0NjAeFw0xNjA4MDQyMjI5MzdaFw0yMTA4MDUyMjI5MzdaMHIxCzAJBgNVBAYTAlVTMSswKQYDVQQKDCJPbmVMb2dpbiBUZXN0IChzZ2FyY2lhLXVzLXByZXByb2QpMRUwEwYDVQQLDAxPbmVMb2dpbiBJZFAxHzAdBgNVBAMMFk9uZUxvZ2luIEFjY291bnQgODkxNDYwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDN6iqQGcLOCglNO42I2rkzE05UXSiMXT6c8ALThMMiaDw6qqzo3sd/tKK+NcNKWLIIC8TozWVyh5ykUiVZps+08xil7VsTU7E+wKu3kvmOsvw2wlRwtnoKZJwYhnr+RkBa+h1r3ZYUgXm1ZPeHMKj1g18KaWz9+MxYL6BhKqrOzfW/P2xxVRcFH7/pq+ZsDdgNzD2GD+apzY4MZyZj/N6BpBWJ0GlFsmtBegpbX3LBitJuFkk5L4/U/jjF1AJa3boBdCUVfATqO5G03H4XS1GySjBIRQXmlUF52rLjg6xCgWJ30/+t1X+IHLJeixiQ0vxyh6C4/usCEt94cgD1r8ADAgMBAAGjgfIwge8wDAYDVR0TAQH/BAIwADAdBgNVHQ4EFgQUPW0DcH0G3IwynWgi74co4wZ6n7gwga8GA1UdIwSBpzCBpIAUPW0DcH0G3IwynWgi74co4wZ6n7ihdqR0MHIxCzAJBgNVBAYTAlVTMSswKQYDVQQKDCJPbmVMb2dpbiBUZXN0IChzZ2FyY2lhLXVzLXByZXByb2QpMRUwEwYDVQQLDAxPbmVMb2dpbiBJZFAxHzAdBgNVBAMMFk9uZUxvZ2luIEFjY291bnQgODkxNDaCFD8svwN22QGeJtvD8xFFKE+0SYcSMA4GA1UdDwEB/wQEAwIHgDANBgkqhkiG9w0BAQUFAAOCAQEAQhB4q9jrycwbHrDSoYR1X4LFFzvJ9Us75wQquRHXpdyS9D6HUBXMGI6ahPicXCQrfLgN8vzMIiqZqfySXXv/8/dxe/X4UsWLYKYJHDJmxXD5EmWTa65chjkeP1oJAc8f3CKCpcP2lOBTthbnk2fEVAeLHR4xNdQO0VvGXWO9BliYPpkYqUIBvlm+Fg9mF7AM/Uagq2503XXIE1Lq//HON68P10vNMwLSKOtYLsoTiCnuIKGJqG37MsZVjQ1ZPRcO+LSLkq0i91gFxrOrVCrgztX4JQi5XkvEsYZGIXXjwHqxTVyt3adZWQO0LPxPqRiUqUzyhDhLo/xXNrHCu4VbMw=='
@@ -70,6 +71,7 @@ class OneLogin_Saml2_IdPMetadataParserTest extends PHPUnit_Framework_TestCase
                 ),
                 'singleLogoutService' => array (
                     'url' => 'https://idp.examle.com/saml/slo',
+                    'responseUrl' => 'https://idp.examle.com/saml/slr',
                     'binding' => 'urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect'
                 ),
                 'x509certMulti' => array (
@@ -180,6 +182,7 @@ class OneLogin_Saml2_IdPMetadataParserTest extends PHPUnit_Framework_TestCase
                     ),
                 "singleLogoutService" => array(
                     "url" => "http://idp.example.com/logout",
+                    'responseUrl' => '',
                     "binding" => "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect"
                 )
             )
@@ -297,6 +300,7 @@ class OneLogin_Saml2_IdPMetadataParserTest extends PHPUnit_Framework_TestCase
             "idp" => array(
                 "singleLogoutService" => array(
                     "url" => "https://idp.examle.com/saml/slo",
+                    'responseUrl' => '',
                     "binding" => "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect"
                 ),
                 "x509certMulti" => array(
@@ -336,6 +340,7 @@ class OneLogin_Saml2_IdPMetadataParserTest extends PHPUnit_Framework_TestCase
             "idp" => array(
                 "singleLogoutService" => array(
                     "url" => "https://idp.examle.com/saml/slo",
+                    'responseUrl' => '',
                     "binding" => "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect"
                 ),
                 "x509certMulti" => array(
@@ -424,6 +429,7 @@ class OneLogin_Saml2_IdPMetadataParserTest extends PHPUnit_Framework_TestCase
                 ),
                 'singleLogoutService' => array (
                     'url' => 'http://stuff.com/endpoints/endpoints/sls.php'
+
                 ),
                 'NameIDFormat' => 'urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress'
             ),
@@ -435,6 +441,7 @@ class OneLogin_Saml2_IdPMetadataParserTest extends PHPUnit_Framework_TestCase
                 ),
                 'singleLogoutService' => array (
                     'url' => 'https://idp.adfs.example.com/adfs/ls/',
+                    'responseUrl' => '',
                     'binding' => 'urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect'
                 ),
                 'x509certMulti' => array (

--- a/tests/src/OneLogin/Saml2/IdPMetadataParserTest.php
+++ b/tests/src/OneLogin/Saml2/IdPMetadataParserTest.php
@@ -429,7 +429,6 @@ class OneLogin_Saml2_IdPMetadataParserTest extends PHPUnit_Framework_TestCase
                 ),
                 'singleLogoutService' => array (
                     'url' => 'http://stuff.com/endpoints/endpoints/sls.php'
-
                 ),
                 'NameIDFormat' => 'urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress'
             ),

--- a/tests/src/OneLogin/Saml2/SettingsTest.php
+++ b/tests/src/OneLogin/Saml2/SettingsTest.php
@@ -333,6 +333,7 @@ class OneLogin_Saml2_SettingsTest extends PHPUnit_Framework_TestCase
         $settingsInfo['idp']['entityID'] = 'entityId';
         $settingsInfo['idp']['singleSignOnService']['url'] = 'invalid_value';
         $settingsInfo['idp']['singleLogoutService']['url'] = 'invalid_value';
+        $settingsInfo['idp']['singleLogoutService']['responseUrl'] = 'invalid_value';
         $settingsInfo['sp']['assertionConsumerService']['url'] = 'invalid_value';
         $settingsInfo['sp']['singleLogoutService']['url'] = 'invalid_value';
         try {
@@ -341,6 +342,7 @@ class OneLogin_Saml2_SettingsTest extends PHPUnit_Framework_TestCase
         } catch (OneLogin_Saml2_error $e) {
             $this->assertContains('idp_sso_url_invalid', $e->getMessage());
             $this->assertContains('idp_slo_url_invalid', $e->getMessage());
+            $this->assertContains('idp_slo_response_url_invalid', $e->getMessage());
             $this->assertContains('sp_acs_url_invalid', $e->getMessage());
             $this->assertContains('sp_sls_url_invalid', $e->getMessage());
         }


### PR DESCRIPTION
I need 1 features that I don't see implemented, unless I didn't find them.

a) Our IdP uses ResponseLocation in addition to Location for its SingleLogoutService.
I.E. its metadata contains:

```
<ns0:SingleLogoutService
  Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect"
  Location="https://<idp url>/idp/saml2/sls"
  ResponseLocation="https://<idp url>/idp/saml2/slr"  # this extra URL
/>
```
But it seems that using this second URL (optional in the SAML spec) isn't supported in php-saml.

To implement it, it seems that we would need to:

* Support the response location URL in lib/Saml2/Settings.php.
* Update logic in ib/Saml2/Auth::process_slo in the case of SAMLResponse to use that URL when available or fall back on the current one.
* Add Auth:getSLOResponseUrl() which gets the responseUrl from Settings or use getSLOurl() if responseUrl is not defined