### PR TITLE
Move the creation of the AuthnRequest to separate function

### DIFF
--- a/src/Saml2/Auth.php
+++ b/src/Saml2/Auth.php
@@ -527,7 +527,7 @@ class Auth
      */
     public function login($returnTo = null, array $parameters = array(), $forceAuthn = false, $isPassive = false, $stay = false, $setNameIdPolicy = true)
     {
-        $authnRequest = new AuthnRequest($this->_settings, $forceAuthn, $isPassive, $setNameIdPolicy);
+        $authnRequest = $this->buildAuthnRequest($this->_settings, $forceAuthn, $isPassive, $setNameIdPolicy);
 
         $this->_lastRequest = $authnRequest->getXML();
         $this->_lastRequestID = $authnRequest->getId();
@@ -640,6 +640,21 @@ class Auth
     public function getLastRequestID()
     {
         return $this->_lastRequestID;
+    }
+
+    /**
+     * Creates an AuthnRequest
+     *
+     * @param Settings $settings        Setting data
+     * @param bool     $forceAuthn      When true the AuthNRequest will set the ForceAuthn='true'
+     * @param bool     $isPassive       When true the AuthNRequest will set the Ispassive='true'
+     * @param bool     $setNameIdPolicy When true the AuthNRequest will set a nameIdPolicy element
+     *
+     * @return AuthnRequest The AuthnRequest object
+     */
+    public function buildAuthnRequest($settings, $forceAuthn, $isPassive, $setNameIdPolicy)
+    {
+        return new AuthnRequest($settings, $forceAuthn, $isPassive, $setNameIdPolicy);
     }
 
     /**


### PR DESCRIPTION
By moving the creation of the AuthnRequest to a separate function, it's easier to extend the `Auth` class to use a custom `AuthnRequest` (to implement extra features like in #211). This way, only the `buildAuthnRequest()` function has to be overridden. 

In the current implementation, overriding the `login()` function to achieve the same goal causes some problems with private variables such as `_settings`.