### PR TITLE
Fix Destination check

### DIFF
--- a/src/Saml2/Response.php
+++ b/src/Saml2/Response.php
@@ -263,10 +263,10 @@ class Response
                             );
                         }
                     } else {
-                        if (strpos($destination, $currentURL) !== 0) {
+                        if (strcmp($destination, $currentURL) !== 0) {
                             $currentURLNoRouted = Utils::getSelfURLNoQuery();
 
-                            if (strpos($destination, $currentURLNoRouted) !== 0) {
+                            if (strcmp($destination, $currentURLNoRouted) !== 0) {
                                 throw new ValidationError(
                                     "The response was received at $currentURL instead of $destination",
                                     ValidationError::WRONG_DESTINATION


### PR DESCRIPTION
The current check with `strpos($destination, $currentURL)` returns 0 if `$currentURL` starts with `$destination`.
Example:
`$destination = https://www.example.com/saml/acswrongvalue`
`$currentURL = https://www.example.com/saml/acs`

Changing `strpos` with `strcmp` fixes the issue.