### PR TITLE
Fix Util::getSelfRoutedURLNoQuery()

### DIFF
--- a/lib/Saml2/Utils.php
+++ b/lib/Saml2/Utils.php
@@ -623,22 +623,21 @@ class OneLogin_Saml2_Utils
         $selfURLhost = self::getSelfURLhost();
         $route = '';
 
-                if (!empty($_SERVER['REQUEST_URI'])) {
+        if (!empty($_SERVER['REQUEST_URI'])) {
             $route = $_SERVER['REQUEST_URI'];
             if (!empty($_SERVER['QUERY_STRING'])) {
-				$queries = explode("&", $_SERVER['QUERY_STRING']);
-				if(!empty($queries)) {
-					foreach($queries AS $query) {
-						$route = str_replace($query, '', $route);
-					}
-				}
-				while(substr($route, -1) == '&') {
-                    $route = substr($route, 0, -1);
-				}
-				if (substr($route, -1) == '?') {
+                $queries = explode("&", $_SERVER['QUERY_STRING']);
+                if(!empty($queries)) {
+                    foreach($queries AS $query) {
+                        $route = str_replace($query, '', $route);
+                    }
+                }
+                while(substr($route, -1) == '&') {
                     $route = substr($route, 0, -1);
                 }
-
+                if (substr($route, -1) == '?') {
+                    $route = substr($route, 0, -1);
+                }
             }
         }
 

--- a/lib/Saml2/Utils.php
+++ b/lib/Saml2/Utils.php
@@ -623,13 +623,22 @@ class OneLogin_Saml2_Utils
         $selfURLhost = self::getSelfURLhost();
         $route = '';
 
-        if (!empty($_SERVER['REQUEST_URI'])) {
+                if (!empty($_SERVER['REQUEST_URI'])) {
             $route = $_SERVER['REQUEST_URI'];
             if (!empty($_SERVER['QUERY_STRING'])) {
-                $route = str_replace($_SERVER['QUERY_STRING'], '', $route);
-                if (substr($route, -1) == '?') {
+				$queries = explode("&", $_SERVER['QUERY_STRING']);
+				if(!empty($queries)) {
+					foreach($queries AS $query) {
+						$route = str_replace($query, '', $route);
+					}
+				}
+				while(substr($route, -1) == '&') {
+                    $route = substr($route, 0, -1);
+				}
+				if (substr($route, -1) == '?') {
                     $route = substr($route, 0, -1);
                 }
+
             }
         }
 


### PR DESCRIPTION
Sometimes the REQUEST_URI's queries are not equal to QUERY_STRING's queries. (The REQUEST_URI can have more queries then the QUERY_STRING's, in some not so rare rewrite conditions). In those cases, the old 1:1 str_replace doesn't work. This PR iterates over each query, and replaces them one by one.
Without this modification the SLOProcess won't work in some cases.
