### PR TITLE
Remove Comparison atribute for empty value

### DIFF
--- a/lib/Saml2/AuthnRequest.php
+++ b/lib/Saml2/AuthnRequest.php
@@ -111,15 +111,20 @@ ISPASSIVE;
                 $authnComparison = $security['requestedAuthnContextComparison'];
             }
 
+            $authnComparisonAttr = '';
+            if (!empty($authnComparison)) {
+                $authnComparisonAttr = sprintf('Comparison="%s"', $authnComparison);
+            }
+
             if ($security['requestedAuthnContext'] === true) {
                 $requestedAuthnStr = <<<REQUESTEDAUTHN
 
-    <samlp:RequestedAuthnContext Comparison="$authnComparison">
+    <samlp:RequestedAuthnContext $authnComparisonAttr>
         <saml:AuthnContextClassRef>urn:oasis:names:tc:SAML:2.0:ac:classes:PasswordProtectedTransport</saml:AuthnContextClassRef>
     </samlp:RequestedAuthnContext>
 REQUESTEDAUTHN;
             } else {
-                $requestedAuthnStr .= "    <samlp:RequestedAuthnContext Comparison=\"$authnComparison\">\n";
+                $requestedAuthnStr .= "    <samlp:RequestedAuthnContext $authnComparisonAttr>\n";
                 foreach ($security['requestedAuthnContext'] as $contextValue) {
                     $requestedAuthnStr .= "        <saml:AuthnContextClassRef>".$contextValue."</saml:AuthnContextClassRef>\n";
                 }

--- a/tests/src/OneLogin/Saml2/AuthnRequestTest.php
+++ b/tests/src/OneLogin/Saml2/AuthnRequestTest.php
@@ -94,6 +94,14 @@ class OneLogin_Saml2_AuthnRequestTest extends PHPUnit_Framework_TestCase
         $decoded5 = base64_decode($encodedRequest5);
         $request5 = gzinflate($decoded5);
         $this->assertContains('<samlp:RequestedAuthnContext Comparison="minimum">', $request5);
+
+        $settingsInfo['security']['requestedAuthnContextComparison'] = '';
+        $settings6 = new OneLogin_Saml2_Settings($settingsInfo);
+        $authnRequest6 = new OneLogin_Saml2_AuthnRequest($settings6);
+        $encodedRequest6 = $authnRequest6->getRequest();
+        $decoded6 = base64_decode($encodedRequest6);
+        $request6 = gzinflate($decoded6);
+        $this->assertContains('<samlp:RequestedAuthnContext >', $request6);
     }
 
     /**


### PR DESCRIPTION
Some Microsoft setup for SAML2 read the empty attributes for a response as an empty string  to avoiding it we should completely remove them from request 

https://shibboleth.1660669.n2.nabble.com/RequestedAuthnContext-Comparison-quot-exact-quot-td7644364.html#a7644392