### PR TITLE
Empty instead of unset the $_SESSION variable

### DIFF
--- a/lib/Saml2/Utils.php
+++ b/lib/Saml2/Utils.php
@@ -966,9 +966,9 @@ class OneLogin_Saml2_Utils
      */
     public static function deleteLocalSession()
     {
+        session_unset();
 
         if (OneLogin_Saml2_Utils::isSessionStarted()) {
-            session_unset();
             session_destroy();
         }
     }

--- a/lib/Saml2/Utils.php
+++ b/lib/Saml2/Utils.php
@@ -971,7 +971,7 @@ class OneLogin_Saml2_Utils
             session_destroy();
         }
 
-        unset($_SESSION);
+        $_SESSION = [];
     }
 
     /**

--- a/lib/Saml2/Utils.php
+++ b/lib/Saml2/Utils.php
@@ -968,10 +968,9 @@ class OneLogin_Saml2_Utils
     {
 
         if (OneLogin_Saml2_Utils::isSessionStarted()) {
+            session_unset();
             session_destroy();
         }
-
-        $_SESSION = [];
     }
 
     /**

--- a/tests/src/OneLogin/Saml2/UtilsTest.php
+++ b/tests/src/OneLogin/Saml2/UtilsTest.php
@@ -370,10 +370,10 @@ class OneLogin_Saml2_UtilsTest extends PHPUnit_Framework_TestCase
     public function testisHTTPS()
     {
         $this->assertFalse(OneLogin_Saml2_Utils::isHTTPS());
-        
+
         $_SERVER['HTTPS'] = 'on';
         $this->assertTrue(OneLogin_Saml2_Utils::isHTTPS());
-    
+
         unset($_SERVER['HTTPS']);
         $this->assertFalse(OneLogin_Saml2_Utils::isHTTPS());
         $_SERVER['HTTP_HOST'] = 'example.com:443';
@@ -482,7 +482,7 @@ class OneLogin_Saml2_UtilsTest extends PHPUnit_Framework_TestCase
         $expectedUrlNQ2 = 'http://anothersp.example.com:81/example2/route.php';
         $expectedRoutedUrlNQ2 = 'http://anothersp.example.com:81/example2/route.php';
         $expectedUrl2 = 'http://anothersp.example.com:81/example2/route.php?x=test';
-        
+
         $this->assertEquals('http', OneLogin_Saml2_Utils::getSelfProtocol());
         $this->assertEquals('anothersp.example.com', OneLogin_Saml2_Utils::getSelfHost());
         $this->assertEquals('81', OneLogin_Saml2_Utils::getSelfPort());
@@ -957,7 +957,7 @@ class OneLogin_Saml2_UtilsTest extends PHPUnit_Framework_TestCase
             $this->assertTrue($_SESSION['samltest']);
 
             OneLogin_Saml2_Utils::deleteLocalSession();
-            $this->assertFalse(isset($_SESSION));
+            $this->assertEmpty($_SESSION);
             $this->assertFalse(isset($_SESSION['samltest']));
 
             $prev = error_reporting(0);
@@ -966,7 +966,7 @@ class OneLogin_Saml2_UtilsTest extends PHPUnit_Framework_TestCase
 
             $_SESSION['samltest'] = true;
             OneLogin_Saml2_Utils::deleteLocalSession();
-            $this->assertFalse(isset($_SESSION));
+            $this->assertEmpty($_SESSION);
             $this->assertFalse(isset($_SESSION['samltest']));
         }
     }


### PR DESCRIPTION
We shouldn't destroy a global variable cause other scripts trust them to be there.
For instance the [`save`](https://github.com/symfony/symfony/blob/c732122b574ecfb083d44324ac18f9508e95471d/src/Symfony/Component/HttpFoundation/Session/Storage/NativeSessionStorage.php#L240) method of the Symfony `NativeSessionStorage` trusts the variable to be there.

Assigning an empty array to the variable would do the trick.