### PR TITLE
Reset the $_SESSION variable if the session isn't started

### DIFF
--- a/lib/Saml2/Utils.php
+++ b/lib/Saml2/Utils.php
@@ -966,10 +966,11 @@ class OneLogin_Saml2_Utils
      */
     public static function deleteLocalSession()
     {
-        session_unset();
-
         if (OneLogin_Saml2_Utils::isSessionStarted()) {
+            session_unset();
             session_destroy();
+        } else {
+            $_SESSION = array();
         }
     }
 


### PR DESCRIPTION
It seems if the session isn't started the function `session_unset()` doesn't work.
I've added an else statement where we assign a new array to the session variable to reset it.

Locally the tests are succeeding now 👍 

Both situations are hit by the testsuite