### PR TITLE
Non-require idp cert on security implicit disabled

### DIFF
--- a/lib/Saml2/Settings.php
+++ b/lib/Saml2/Settings.php
@@ -564,7 +564,7 @@ class OneLogin_Saml2_Settings
                 $errors[] = 'idp_slo_response_url_invalid';
             }
 
-            if (isset($settings['security'])) {
+            if (isset($settings['security']) && empty(array_filter($array["security"]))) {
                 $security = $settings['security'];
 
                 $existsX509 = isset($idp['x509cert']) && !empty($idp['x509cert']);

--- a/lib/Saml2/Settings.php
+++ b/lib/Saml2/Settings.php
@@ -564,7 +564,7 @@ class OneLogin_Saml2_Settings
                 $errors[] = 'idp_slo_response_url_invalid';
             }
 
-            if (isset($settings['security']) && !empty(array_filter($array["security"]))) {
+            if (isset($settings['security']) && !empty(array_filter($settings["security"]))) {
                 $security = $settings['security'];
 
                 $existsX509 = isset($idp['x509cert']) && !empty($idp['x509cert']);

--- a/lib/Saml2/Settings.php
+++ b/lib/Saml2/Settings.php
@@ -564,7 +564,7 @@ class OneLogin_Saml2_Settings
                 $errors[] = 'idp_slo_response_url_invalid';
             }
 
-            if (isset($settings['security']) && empty(array_filter($array["security"]))) {
+            if (isset($settings['security']) && !empty(array_filter($array["security"]))) {
                 $security = $settings['security'];
 
                 $existsX509 = isset($idp['x509cert']) && !empty($idp['x509cert']);


### PR DESCRIPTION
For configuration like:
```
["security"]=>
  array(8) {
    ["nameIdEncrypted"]=>
    bool(false)
    ["authnRequestsSigned"]=>
    bool(false)
    ["logoutRequestSigned"]=>
    bool(false)
    ["logoutResponseSigned"]=>
    bool(false)
    ["wantMessagesSigned"]=>
    bool(false)
    ["wantAssertionsEncrypted"]=>
    bool(false)
    ["wantAssertionsSigned"]=>
    bool(false)
    ["wantNameIdEncrypted"]=>
    bool(false)
  }
```
there is no reason to require idp cert. 

I have no clue about PHP-SAML. I'm just trying to run SAML in Zabbix and I ran into this potential problem.