### PR TITLE
Add Auth Context Class Constants

### DIFF
--- a/lib/Saml2/Constants.php
+++ b/lib/Saml2/Constants.php
@@ -49,9 +49,11 @@ class OneLogin_Saml2_Constants
     const AC_PASSWORD_PROTECTED = 'urn:oasis:names:tc:SAML:2.0:ac:classes:PasswordProtectedTransport';
     const AC_X509 = 'urn:oasis:names:tc:SAML:2.0:ac:classes:X509';
     const AC_SMARTCARD = 'urn:oasis:names:tc:SAML:2.0:ac:classes:Smartcard';
+    const AC_SMARTCARD_PKI = 'urn:oasis:names:tc:SAML:2.0:ac:classes:SmartcardPKI';
     const AC_KERBEROS = 'urn:oasis:names:tc:SAML:2.0:ac:classes:Kerberos';
     const AC_WINDOWS = 'urn:federation:authentication:windows';
     const AC_TLS = 'urn:oasis:names:tc:SAML:2.0:ac:classes:TLSClient';
+    const AC_RSATOKEN = 'urn:oasis:names:tc:SAML:2.0:ac:classes:TimeSyncToken';
 
     // Subject Confirmation
     const CM_BEARER = 'urn:oasis:names:tc:SAML:2.0:cm:bearer';


### PR DESCRIPTION
Adding additional Auth Context Class Constants for RSA TimeSync Token, and Federal PIV cards