### PR TITLE
PHP 8 Support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         "source": "https://github.com/onelogin/php-saml/"
     },
     "require": {
-        "php": ">=5.4 <8.0",
+        "php": ">=5.4",
         "robrichards/xmlseclibs": ">=3.1.1",
         "phpunit/phpunit": "<7.5.18"
     },

--- a/src/Saml2/Utils.php
+++ b/src/Saml2/Utils.php
@@ -82,11 +82,16 @@ class Utils
         assert($dom instanceof DOMDocument);
         assert(is_string($xml));
 
-        $oldEntityLoader = libxml_disable_entity_loader(true);
+        $oldEntityLoader = null;
+        if (PHP_VERSION_ID < 80000) {
+            $oldEntityLoader = libxml_disable_entity_loader(true);
+        }
 
         $res = $dom->loadXML($xml);
 
-        libxml_disable_entity_loader($oldEntityLoader);
+        if (PHP_VERSION_ID < 80000) {
+            libxml_disable_entity_loader($oldEntityLoader);
+        }
 
         foreach ($dom->childNodes as $child) {
             if ($child->nodeType === XML_DOCUMENT_TYPE_NODE) {
@@ -141,9 +146,14 @@ class Utils
             $schemaFile = __DIR__ . '/schemas/' . $schema;
         }
 
-        $oldEntityLoader = libxml_disable_entity_loader(false);
+        $oldEntityLoader = null;
+        if (PHP_VERSION_ID < 80000) {
+            $oldEntityLoader = libxml_disable_entity_loader(false);
+        }
         $res = $dom->schemaValidate($schemaFile);
-        libxml_disable_entity_loader($oldEntityLoader);
+        if (PHP_VERSION_ID < 80000) {
+            libxml_disable_entity_loader($oldEntityLoader);
+        }
         if (!$res) {
             $xmlErrors = libxml_get_errors();
             syslog(LOG_INFO, 'Error validating the metadata: '.var_export($xmlErrors, true));


### PR DESCRIPTION
Related to original PR: https://github.com/onelogin/php-saml/pull/456 and issue https://github.com/onelogin/php-saml/issues/453

This updates the library to work with php 8, ignoring the issues with updating  tests (which will be a secondary PR).