### PR TITLE
PHP 8 test suite

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@
 /vendor
 /composer.lock
 /.idea
+/.phpunit.result.cache

--- a/composer.json
+++ b/composer.json
@@ -15,14 +15,14 @@
         "source": "https://github.com/onelogin/php-saml/"
     },
     "require": {
-        "php": ">=5.4",
+        "php": ">=7.0",
         "robrichards/xmlseclibs": ">=3.1.1",
-        "phpunit/phpunit": "<7.5.18"
+        "phpunit/phpunit": "7.5.17 || ^9.5"
     },
     "require-dev": {
         "php-coveralls/php-coveralls": "^1.0.2 || ^2.0",
         "sebastian/phpcpd": "^2.0 || ^3.0 || ^4.0",
-        "phploc/phploc": "^2.1 || ^3.0 || ^4.0",
+        "phploc/phploc": "^2.1 || ^3.0 || ^4.0 || ^7.0",
         "pdepend/pdepend": "^2.5.0",
         "squizlabs/php_codesniffer": "^3.1.1"
     },

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         "source": "https://github.com/onelogin/php-saml/"
     },
     "require": {
-        "php": ">=7.0",
+        "php": ">=7.1",
         "robrichards/xmlseclibs": ">=3.1.1",
         "phpunit/phpunit": "7.5.17 || ^9.5"
     },

--- a/tests/src/OneLogin/Saml2/AuthTest.php
+++ b/tests/src/OneLogin/Saml2/AuthTest.php
@@ -24,7 +24,7 @@ class AuthTest extends \PHPUnit\Framework\TestCase
     /**
      * Initializes the Test Suite
      */
-    public function setUp()
+    public function setUp() : void
     {
         $settingsDir = TEST_ROOT .'/settings/';
         include $settingsDir.'settings1.php';
@@ -116,7 +116,7 @@ class AuthTest extends \PHPUnit\Framework\TestCase
             $this->_auth->processResponse();
             $this->fail('Error was not raised');
         } catch (Error $e) {
-            $this->assertContains('SAML Response not found', $e->getMessage());
+            $this->assertStringContainsString('SAML Response not found', $e->getMessage());
         }
 
         $this->assertEquals($this->_auth->getErrors(), array('invalid_binding'));
@@ -349,7 +349,7 @@ class AuthTest extends \PHPUnit\Framework\TestCase
             $auth4->processResponse();
             $this->fail('OneLogin\Saml2\ValidationError was not raised');
         } catch (ValidationError $e) {
-            $this->assertContains('Found an Attribute element with duplicated FriendlyName', $e->getMessage());
+            $this->assertStringContainsString('Found an Attribute element with duplicated FriendlyName', $e->getMessage());
         }
         $response5 = file_get_contents(TEST_ROOT . '/data/responses/invalids/duplicated_attributes.xml.base64');
         $_POST['SAMLResponse'] = $response5;
@@ -358,7 +358,7 @@ class AuthTest extends \PHPUnit\Framework\TestCase
             $auth5->processResponse();
             $this->fail('OneLogin\Saml2\ValidationError was not raised');
         } catch (ValidationError $e) {
-            $this->assertContains('Found an Attribute element with duplicated Name', $e->getMessage());
+            $this->assertStringContainsString('Found an Attribute element with duplicated Name', $e->getMessage());
         }
     }
 
@@ -383,7 +383,7 @@ class AuthTest extends \PHPUnit\Framework\TestCase
             // Do not ever get here
             $this->assertFalse(true);
         } catch (Exception $e) {
-            $this->assertContains('Cannot modify header information', $e->getMessage());
+            $this->assertStringContainsString('Cannot modify header information', $e->getMessage());
             $trace = $e->getTrace();
             $targetUrl = getUrlFromRedirect($trace);
 
@@ -413,7 +413,7 @@ class AuthTest extends \PHPUnit\Framework\TestCase
             // Do not ever get here
             $this->assertFalse(true);
         } catch (Exception $e) {
-            $this->assertContains('Cannot modify header information', $e->getMessage());
+            $this->assertStringContainsString('Cannot modify header information', $e->getMessage());
             $trace = $e->getTrace();
             $targetUrl = getUrlFromRedirect($trace);
 
@@ -433,7 +433,7 @@ class AuthTest extends \PHPUnit\Framework\TestCase
             $this->_auth->processSLO(true);
             $this->fail('Error was not raised');
         } catch (Error $e) {
-            $this->assertContains('SAML LogoutRequest/LogoutResponse not found', $e->getMessage());
+            $this->assertStringContainsString('SAML LogoutRequest/LogoutResponse not found', $e->getMessage());
         }
 
         $this->assertEquals($this->_auth->getErrors(), array('invalid_binding'));
@@ -633,7 +633,7 @@ class AuthTest extends \PHPUnit\Framework\TestCase
 
         $this->assertEmpty($this->_auth->getErrors());
         $sloResponseUrl = $this->_settingsInfo['idp']['singleLogoutService']['responseUrl'];
-        $this->assertContains($sloResponseUrl, $targetUrl);
+        $this->assertStringContainsString($sloResponseUrl, $targetUrl);
         $this->assertArrayHasKey('SAMLResponse', $parsedQuery);
         $this->assertArrayNotHasKey('RelayState', $parsedQuery);
 
@@ -648,7 +648,7 @@ class AuthTest extends \PHPUnit\Framework\TestCase
 
         $this->assertEmpty($this->_auth->getErrors());
         $sloResponseUrl = $this->_settingsInfo['idp']['singleLogoutService']['responseUrl'];
-        $this->assertContains($sloResponseUrl, $targetUrl);
+        $this->assertStringContainsString($sloResponseUrl, $targetUrl);
         $this->assertArrayHasKey('SAMLResponse', $parsedQuery);
         $this->assertArrayNotHasKey('RelayState', $parsedQuery);
     }
@@ -711,13 +711,13 @@ class AuthTest extends \PHPUnit\Framework\TestCase
             $this->_auth->processSLO(false);
             $this->assertFalse(true);
         } catch (Exception $e) {
-            $this->assertContains('Cannot modify header information', $e->getMessage());
+            $this->assertStringContainsString('Cannot modify header information', $e->getMessage());
             $trace = $e->getTrace();
             $targetUrl = getUrlFromRedirect($trace);
             $parsedQuery = getParamsFromUrl($targetUrl);
 
             $sloResponseUrl = $this->_settingsInfo['idp']['singleLogoutService']['responseUrl'];
-            $this->assertContains($sloResponseUrl, $targetUrl);
+            $this->assertStringContainsString($sloResponseUrl, $targetUrl);
             $this->assertArrayHasKey('SAMLResponse', $parsedQuery);
             $this->assertArrayNotHasKey('RelayState', $parsedQuery);
 
@@ -732,13 +732,13 @@ class AuthTest extends \PHPUnit\Framework\TestCase
             $this->_auth->processSLO(true);
             $this->assertFalse(true);
         } catch (Exception $e) {
-            $this->assertContains('Cannot modify header information', $e->getMessage());
+            $this->assertStringContainsString('Cannot modify header information', $e->getMessage());
             $trace = $e->getTrace();
             $targetUrl = getUrlFromRedirect($trace);
             $parsedQuery = getParamsFromUrl($targetUrl);
 
             $sloResponseUrl = $this->_settingsInfo['idp']['singleLogoutService']['responseUrl'];
-            $this->assertContains($sloResponseUrl, $targetUrl);
+            $this->assertStringContainsString($sloResponseUrl, $targetUrl);
             $this->assertArrayHasKey('SAMLResponse', $parsedQuery);
             $this->assertArrayNotHasKey('RelayState', $parsedQuery);
 
@@ -785,13 +785,13 @@ class AuthTest extends \PHPUnit\Framework\TestCase
             $this->_auth->processSLO(false, null, false, $callback);
             $this->assertFalse(true);
         } catch (Exception $e) {
-            $this->assertContains('Cannot modify header information', $e->getMessage());
+            $this->assertStringContainsString('Cannot modify header information', $e->getMessage());
             $trace = $e->getTrace();
             $targetUrl = getUrlFromRedirect($trace);
             $parsedQuery = getParamsFromUrl($targetUrl);
 
             $sloResponseUrl = $this->_settingsInfo['idp']['singleLogoutService']['responseUrl'];;;
-            $this->assertContains($sloResponseUrl, $targetUrl);
+            $this->assertStringContainsString($sloResponseUrl, $targetUrl);
             $this->assertArrayHasKey('SAMLResponse', $parsedQuery);
             $this->assertArrayNotHasKey('RelayState', $parsedQuery);
 
@@ -835,13 +835,13 @@ class AuthTest extends \PHPUnit\Framework\TestCase
             $this->_auth->processSLO(false);
             $this->assertFalse(true);
         } catch (Exception $e) {
-            $this->assertContains('Cannot modify header information', $e->getMessage());
+            $this->assertStringContainsString('Cannot modify header information', $e->getMessage());
             $trace = $e->getTrace();
             $targetUrl = getUrlFromRedirect($trace);
             $parsedQuery = getParamsFromUrl($targetUrl);
 
             $sloResponseUrl = $this->_settingsInfo['idp']['singleLogoutService']['responseUrl'];
-            $this->assertContains($sloResponseUrl, $targetUrl);
+            $this->assertStringContainsString($sloResponseUrl, $targetUrl);
             $this->assertArrayHasKey('SAMLResponse', $parsedQuery);
             $this->assertArrayHasKey('RelayState', $parsedQuery);
             $this->assertEquals('http://relaystate.com', $parsedQuery['RelayState']);
@@ -883,13 +883,13 @@ class AuthTest extends \PHPUnit\Framework\TestCase
             $auth->processSLO(false);
             $this->assertFalse(true);
         } catch (Exception $e) {
-            $this->assertContains('Cannot modify header information', $e->getMessage());
+            $this->assertStringContainsString('Cannot modify header information', $e->getMessage());
             $trace = $e->getTrace();
             $targetUrl = getUrlFromRedirect($trace);
             $parsedQuery = getParamsFromUrl($targetUrl);
 
             $sloResponseUrl = $this->_settingsInfo['idp']['singleLogoutService']['responseUrl'];
-            $this->assertContains($sloResponseUrl, $targetUrl);
+            $this->assertStringContainsString($sloResponseUrl, $targetUrl);
             $this->assertArrayHasKey('SAMLResponse', $parsedQuery);
             $this->assertArrayHasKey('RelayState', $parsedQuery);
             $this->assertArrayHasKey('SigAlg', $parsedQuery);
@@ -916,13 +916,13 @@ class AuthTest extends \PHPUnit\Framework\TestCase
             // Do not ever get here
             $this->assertFalse(true);
         } catch (Exception $e) {
-            $this->assertContains('Cannot modify header information', $e->getMessage());
+            $this->assertStringContainsString('Cannot modify header information', $e->getMessage());
             $trace = $e->getTrace();
             $targetUrl = getUrlFromRedirect($trace);
             $parsedQuery = getParamsFromUrl($targetUrl);
 
             $ssoUrl = $this->_settingsInfo['idp']['singleSignOnService']['url'];
-            $this->assertContains($ssoUrl, $targetUrl);
+            $this->assertStringContainsString($ssoUrl, $targetUrl);
             $this->assertArrayHasKey('SAMLRequest', $parsedQuery);
             $this->assertArrayHasKey('RelayState', $parsedQuery);
             $this->assertEquals($parsedQuery['RelayState'], Utils::getSelfRoutedURLNoQuery());
@@ -948,13 +948,13 @@ class AuthTest extends \PHPUnit\Framework\TestCase
             // Do not ever get here
             $this->assertFalse(true);
         } catch (Exception $e) {
-            $this->assertContains('Cannot modify header information', $e->getMessage());
+            $this->assertStringContainsString('Cannot modify header information', $e->getMessage());
             $trace = $e->getTrace();
             $targetUrl = getUrlFromRedirect($trace);
             $parsedQuery = getParamsFromUrl($targetUrl);
 
             $ssoUrl = $this->_settingsInfo['idp']['singleSignOnService']['url'];
-            $this->assertContains($ssoUrl, $targetUrl);
+            $this->assertStringContainsString($ssoUrl, $targetUrl);
             $this->assertArrayHasKey('SAMLRequest', $parsedQuery);
             $this->assertArrayHasKey('RelayState', $parsedQuery);
             $this->assertEquals($parsedQuery['RelayState'], $relayState);
@@ -982,13 +982,13 @@ class AuthTest extends \PHPUnit\Framework\TestCase
             // Do not ever get here
             $this->assertFalse(true);
         } catch (Exception $e) {
-            $this->assertContains('Cannot modify header information', $e->getMessage());
+            $this->assertStringContainsString('Cannot modify header information', $e->getMessage());
             $trace = $e->getTrace();
             $targetUrl = getUrlFromRedirect($trace);
             $parsedQuery = getParamsFromUrl($targetUrl);
 
             $ssoUrl = $this->_settingsInfo['idp']['singleSignOnService']['url'];
-            $this->assertContains($ssoUrl, $targetUrl);
+            $this->assertStringContainsString($ssoUrl, $targetUrl);
             $this->assertArrayHasKey('SAMLRequest', $parsedQuery);
             $this->assertArrayHasKey('RelayState', $parsedQuery);
             $this->assertEquals($parsedQuery['RelayState'], $relayState);
@@ -1024,13 +1024,13 @@ class AuthTest extends \PHPUnit\Framework\TestCase
             // Do not ever get here
             $this->assertFalse(true);
         } catch (Exception $e) {
-            $this->assertContains('Cannot modify header information', $e->getMessage());
+            $this->assertStringContainsString('Cannot modify header information', $e->getMessage());
             $trace = $e->getTrace();
             $targetUrl = getUrlFromRedirect($trace);
             $parsedQuery = getParamsFromUrl($targetUrl);
 
             $ssoUrl = $settingsInfo['idp']['singleSignOnService']['url'];
-            $this->assertContains($ssoUrl, $targetUrl);
+            $this->assertStringContainsString($ssoUrl, $targetUrl);
             $this->assertArrayHasKey('SAMLRequest', $parsedQuery);
             $this->assertArrayHasKey('RelayState', $parsedQuery);
             $this->assertArrayHasKey('SigAlg', $parsedQuery);
@@ -1065,13 +1065,13 @@ class AuthTest extends \PHPUnit\Framework\TestCase
             // Do not ever get here
             $this->assertFalse(true);
         } catch (Exception $e) {
-            $this->assertContains('Cannot modify header information', $e->getMessage());
+            $this->assertStringContainsString('Cannot modify header information', $e->getMessage());
             $trace = $e->getTrace();
             $targetUrl = getUrlFromRedirect($trace);
             $parsedQuery = getParamsFromUrl($targetUrl);
 
             $ssoUrl = $settingsInfo['idp']['singleSignOnService']['url'];
-            $this->assertContains($ssoUrl, $targetUrl);
+            $this->assertStringContainsString($ssoUrl, $targetUrl);
             $this->assertArrayHasKey('SAMLRequest', $parsedQuery);
             $encodedRequest = $parsedQuery['SAMLRequest'];
             $decoded = base64_decode($encodedRequest);
@@ -1087,13 +1087,13 @@ class AuthTest extends \PHPUnit\Framework\TestCase
             // Do not ever get here
             $this->assertFalse(true);
         } catch (Exception $e) {
-            $this->assertContains('Cannot modify header information', $e->getMessage());
+            $this->assertStringContainsString('Cannot modify header information', $e->getMessage());
             $trace2 = $e->getTrace();
             $targetUrl2 = getUrlFromRedirect($trace2);
             $parsedQuery2 = getParamsFromUrl($targetUrl2);
 
             $ssoUrl2 = $settingsInfo['idp']['singleSignOnService']['url'];
-            $this->assertContains($ssoUrl2, $targetUrl2);
+            $this->assertStringContainsString($ssoUrl2, $targetUrl2);
             $this->assertArrayHasKey('SAMLRequest', $parsedQuery2);
             $encodedRequest2 = $parsedQuery2['SAMLRequest'];
             $decoded2 = base64_decode($encodedRequest2);
@@ -1108,18 +1108,18 @@ class AuthTest extends \PHPUnit\Framework\TestCase
             // Do not ever get here
             $this->assertFalse(true);
         } catch (Exception $e) {
-            $this->assertContains('Cannot modify header information', $e->getMessage());
+            $this->assertStringContainsString('Cannot modify header information', $e->getMessage());
             $trace3 = $e->getTrace();
             $targetUrl3 = getUrlFromRedirect($trace3);
             $parsedQuery3 = getParamsFromUrl($targetUrl3);
 
             $ssoUrl3 = $settingsInfo['idp']['singleSignOnService']['url'];
-            $this->assertContains($ssoUrl3, $targetUrl3);
+            $this->assertStringContainsString($ssoUrl3, $targetUrl3);
             $this->assertArrayHasKey('SAMLRequest', $parsedQuery3);
             $encodedRequest3 = $parsedQuery3['SAMLRequest'];
             $decoded3 = base64_decode($encodedRequest3);
             $request3 = gzinflate($decoded3);
-            $this->assertContains('ForceAuthn="true"', $request3);
+            $this->assertStringContainsString('ForceAuthn="true"', $request3);
         }
 
     }
@@ -1149,13 +1149,13 @@ class AuthTest extends \PHPUnit\Framework\TestCase
             // Do not ever get here
             $this->assertFalse(true);
         } catch (Exception $e) {
-            $this->assertContains('Cannot modify header information', $e->getMessage());
+            $this->assertStringContainsString('Cannot modify header information', $e->getMessage());
             $trace = $e->getTrace();
             $targetUrl = getUrlFromRedirect($trace);
             $parsedQuery = getParamsFromUrl($targetUrl);
 
             $ssoUrl = $settingsInfo['idp']['singleSignOnService']['url'];
-            $this->assertContains($ssoUrl, $targetUrl);
+            $this->assertStringContainsString($ssoUrl, $targetUrl);
             $this->assertArrayHasKey('SAMLRequest', $parsedQuery);
             $encodedRequest = $parsedQuery['SAMLRequest'];
             $decoded = base64_decode($encodedRequest);
@@ -1170,13 +1170,13 @@ class AuthTest extends \PHPUnit\Framework\TestCase
             // Do not ever get here
             $this->assertFalse(true);
         } catch (Exception $e) {
-            $this->assertContains('Cannot modify header information', $e->getMessage());
+            $this->assertStringContainsString('Cannot modify header information', $e->getMessage());
             $trace2 = $e->getTrace();
             $targetUrl2 = getUrlFromRedirect($trace2);
             $parsedQuery2 = getParamsFromUrl($targetUrl2);
 
             $ssoUrl2 = $settingsInfo['idp']['singleSignOnService']['url'];
-            $this->assertContains($ssoUrl2, $targetUrl2);
+            $this->assertStringContainsString($ssoUrl2, $targetUrl2);
             $this->assertArrayHasKey('SAMLRequest', $parsedQuery2);
             $encodedRequest2 = $parsedQuery2['SAMLRequest'];
             $decoded2 = base64_decode($encodedRequest2);
@@ -1191,18 +1191,18 @@ class AuthTest extends \PHPUnit\Framework\TestCase
             // Do not ever get here
             $this->assertFalse(true);
         } catch (Exception $e) {
-            $this->assertContains('Cannot modify header information', $e->getMessage());
+            $this->assertStringContainsString('Cannot modify header information', $e->getMessage());
             $trace3 = $e->getTrace();
             $targetUrl3 = getUrlFromRedirect($trace3);
             $parsedQuery3 = getParamsFromUrl($targetUrl3);
 
             $ssoUrl3 = $settingsInfo['idp']['singleSignOnService']['url'];
-            $this->assertContains($ssoUrl3, $targetUrl3);
+            $this->assertStringContainsString($ssoUrl3, $targetUrl3);
             $this->assertArrayHasKey('SAMLRequest', $parsedQuery3);
             $encodedRequest3 = $parsedQuery3['SAMLRequest'];
             $decoded3 = base64_decode($encodedRequest3);
             $request3 = gzinflate($decoded3);
-            $this->assertContains('IsPassive="true"', $request3);
+            $this->assertStringContainsString('IsPassive="true"', $request3);
         }
     }
 
@@ -1229,13 +1229,13 @@ class AuthTest extends \PHPUnit\Framework\TestCase
             // Do not ever get here
             $this->assertFalse(true);
         } catch (Exception $e) {
-            $this->assertContains('Cannot modify header information', $e->getMessage());
+            $this->assertStringContainsString('Cannot modify header information', $e->getMessage());
             $trace = $e->getTrace();
             $targetUrl = getUrlFromRedirect($trace);
             $parsedQuery = getParamsFromUrl($targetUrl);
 
             $ssoUrl = $settingsInfo['idp']['singleSignOnService']['url'];
-            $this->assertContains($ssoUrl, $targetUrl);
+            $this->assertStringContainsString($ssoUrl, $targetUrl);
             $this->assertArrayHasKey('SAMLRequest', $parsedQuery);
             $encodedRequest = $parsedQuery['SAMLRequest'];
             $decoded = base64_decode($encodedRequest);
@@ -1250,18 +1250,18 @@ class AuthTest extends \PHPUnit\Framework\TestCase
             // Do not ever get here
             $this->assertFalse(true);
         } catch (Exception $e) {
-            $this->assertContains('Cannot modify header information', $e->getMessage());
+            $this->assertStringContainsString('Cannot modify header information', $e->getMessage());
             $trace2 = $e->getTrace();
             $targetUrl2 = getUrlFromRedirect($trace2);
             $parsedQuery2 = getParamsFromUrl($targetUrl2);
 
             $ssoUrl2 = $settingsInfo['idp']['singleSignOnService']['url'];
-            $this->assertContains($ssoUrl2, $targetUrl2);
+            $this->assertStringContainsString($ssoUrl2, $targetUrl2);
             $this->assertArrayHasKey('SAMLRequest', $parsedQuery2);
             $encodedRequest2 = $parsedQuery2['SAMLRequest'];
             $decoded2 = base64_decode($encodedRequest2);
             $request2 = gzinflate($decoded2);
-            $this->assertContains('<samlp:NameIDPolicy', $request2);
+            $this->assertStringContainsString('<samlp:NameIDPolicy', $request2);
         }
 
         try {
@@ -1271,28 +1271,28 @@ class AuthTest extends \PHPUnit\Framework\TestCase
             // Do not ever get here
             $this->assertFalse(true);
         } catch (Exception $e) {
-            $this->assertContains('Cannot modify header information', $e->getMessage());
+            $this->assertStringContainsString('Cannot modify header information', $e->getMessage());
             $trace3 = $e->getTrace();
             $targetUrl3 = getUrlFromRedirect($trace3);
             $parsedQuery3 = getParamsFromUrl($targetUrl3);
 
             $ssoUrl3 = $settingsInfo['idp']['singleSignOnService']['url'];
-            $this->assertContains($ssoUrl3, $targetUrl3);
+            $this->assertStringContainsString($ssoUrl3, $targetUrl3);
             $this->assertArrayHasKey('SAMLRequest', $parsedQuery3);
             $encodedRequest3 = $parsedQuery3['SAMLRequest'];
             $decoded3 = base64_decode($encodedRequest3);
             $request3 = gzinflate($decoded3);
-            $this->assertContains('<samlp:NameIDPolicy', $request3);
+            $this->assertStringContainsString('<samlp:NameIDPolicy', $request3);
         }
     }
 
     /**
-    * Tests the login method of the Auth class
-    * Case Login with no parameters. A AuthN Request is built with and without Subject
-    *
-    * @covers OneLogin\Saml2\Auth::login
-    * @runInSeparateProcess
-    */
+     * Tests the login method of the Auth class
+     * Case Login with no parameters. A AuthN Request is built with and without Subject
+     *
+     * @covers OneLogin\Saml2\Auth::login
+     * @runInSeparateProcess
+     */
     public function testLoginSubject()
     {
         $settingsDir = TEST_ROOT .'/settings/';
@@ -1306,13 +1306,13 @@ class AuthTest extends \PHPUnit\Framework\TestCase
             // Do not ever get here
             $this->assertFalse(true);
         } catch (Exception $e) {
-            $this->assertContains('Cannot modify header information', $e->getMessage());
+            $this->assertStringContainsString('Cannot modify header information', $e->getMessage());
             $trace = $e->getTrace();
             $targetUrl = getUrlFromRedirect($trace);
             $parsedQuery = getParamsFromUrl($targetUrl);
 
             $ssoUrl = $settingsInfo['idp']['singleSignOnService']['url'];
-            $this->assertContains($ssoUrl, $targetUrl);
+            $this->assertStringContainsString($ssoUrl, $targetUrl);
             $this->assertArrayHasKey('SAMLRequest', $parsedQuery);
             $encodedRequest = $parsedQuery['SAMLRequest'];
             $decoded = base64_decode($encodedRequest);
@@ -1327,20 +1327,20 @@ class AuthTest extends \PHPUnit\Framework\TestCase
             // Do not ever get here
             $this->assertFalse(true);
         } catch (Exception $e) {
-            $this->assertContains('Cannot modify header information', $e->getMessage());
+            $this->assertStringContainsString('Cannot modify header information', $e->getMessage());
             $trace2 = $e->getTrace();
             $targetUrl2 = getUrlFromRedirect($trace2);
             $parsedQuery2 = getParamsFromUrl($targetUrl2);
 
             $ssoUrl2 = $settingsInfo['idp']['singleSignOnService']['url'];
-            $this->assertContains($ssoUrl2, $targetUrl2);
+            $this->assertStringContainsString($ssoUrl2, $targetUrl2);
             $this->assertArrayHasKey('SAMLRequest', $parsedQuery2);
             $encodedRequest2 = $parsedQuery2['SAMLRequest'];
             $decoded2 = base64_decode($encodedRequest2);
             $request2 = gzinflate($decoded2);
-            $this->assertContains('<saml:Subject', $request2);
-            $this->assertContains('Format="urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified">testuser@example.com</saml:NameID>', $request2);
-            $this->assertContains('<saml:SubjectConfirmation Method="urn:oasis:names:tc:SAML:2.0:cm:bearer">', $request2);
+            $this->assertStringContainsString('<saml:Subject', $request2);
+            $this->assertStringContainsString('Format="urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified">testuser@example.com</saml:NameID>', $request2);
+            $this->assertStringContainsString('<saml:SubjectConfirmation Method="urn:oasis:names:tc:SAML:2.0:cm:bearer">', $request2);
         }
 
         try {
@@ -1352,20 +1352,20 @@ class AuthTest extends \PHPUnit\Framework\TestCase
             // Do not ever get here
             $this->assertFalse(true);
         } catch (Exception $e) {
-            $this->assertContains('Cannot modify header information', $e->getMessage());
+            $this->assertStringContainsString('Cannot modify header information', $e->getMessage());
             $trace3 = $e->getTrace();
             $targetUrl3 = getUrlFromRedirect($trace3);
             $parsedQuery3 = getParamsFromUrl($targetUrl3);
 
             $ssoUrl3 = $settingsInfo['idp']['singleSignOnService']['url'];
-            $this->assertContains($ssoUrl3, $targetUrl3);
+            $this->assertStringContainsString($ssoUrl3, $targetUrl3);
             $this->assertArrayHasKey('SAMLRequest', $parsedQuery3);
             $encodedRequest3 = $parsedQuery3['SAMLRequest'];
             $decoded3 = base64_decode($encodedRequest3);
             $request3 = gzinflate($decoded3);
-            $this->assertContains('<saml:Subject', $request3);
-            $this->assertContains('Format="urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress">testuser@example.com</saml:NameID>', $request3);
-            $this->assertContains('<saml:SubjectConfirmation Method="urn:oasis:names:tc:SAML:2.0:cm:bearer">', $request3);
+            $this->assertStringContainsString('<saml:Subject', $request3);
+            $this->assertStringContainsString('Format="urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress">testuser@example.com</saml:NameID>', $request3);
+            $this->assertStringContainsString('<saml:SubjectConfirmation Method="urn:oasis:names:tc:SAML:2.0:cm:bearer">', $request3);
         }
     }
 
@@ -1386,13 +1386,13 @@ class AuthTest extends \PHPUnit\Framework\TestCase
             // Do not ever get here
             $this->assertFalse(true);
         } catch (Exception $e) {
-            $this->assertContains('Cannot modify header information', $e->getMessage());
+            $this->assertStringContainsString('Cannot modify header information', $e->getMessage());
             $trace = $e->getTrace();
             $targetUrl = getUrlFromRedirect($trace);
             $parsedQuery = getParamsFromUrl($targetUrl);
 
             $sloUrl = $this->_settingsInfo['idp']['singleLogoutService']['url'];
-            $this->assertContains($sloUrl, $targetUrl);
+            $this->assertStringContainsString($sloUrl, $targetUrl);
             $this->assertArrayHasKey('SAMLRequest', $parsedQuery);
             $this->assertArrayHasKey('RelayState', $parsedQuery);
             $this->assertEquals($parsedQuery['RelayState'], Utils::getSelfRoutedURLNoQuery());
@@ -1418,13 +1418,13 @@ class AuthTest extends \PHPUnit\Framework\TestCase
             // Do not ever get here
             $this->assertFalse(true);
         } catch (Exception $e) {
-            $this->assertContains('Cannot modify header information', $e->getMessage());
+            $this->assertStringContainsString('Cannot modify header information', $e->getMessage());
             $trace = $e->getTrace();
             $targetUrl = getUrlFromRedirect($trace);
             $parsedQuery = getParamsFromUrl($targetUrl);
 
             $sloUrl = $this->_settingsInfo['idp']['singleLogoutService']['url'];
-            $this->assertContains($sloUrl, $targetUrl);
+            $this->assertStringContainsString($sloUrl, $targetUrl);
             $this->assertArrayHasKey('SAMLRequest', $parsedQuery);
             $this->assertArrayHasKey('RelayState', $parsedQuery);
             $this->assertEquals($parsedQuery['RelayState'], $relayState);
@@ -1452,13 +1452,13 @@ class AuthTest extends \PHPUnit\Framework\TestCase
             // Do not ever get here
             $this->assertFalse(true);
         } catch (Exception $e) {
-            $this->assertContains('Cannot modify header information', $e->getMessage());
+            $this->assertStringContainsString('Cannot modify header information', $e->getMessage());
             $trace = $e->getTrace();
             $targetUrl = getUrlFromRedirect($trace);
             $parsedQuery = getParamsFromUrl($targetUrl);
 
             $sloUrl = $this->_settingsInfo['idp']['singleLogoutService']['url'];
-            $this->assertContains($sloUrl, $targetUrl);
+            $this->assertStringContainsString($sloUrl, $targetUrl);
             $this->assertArrayHasKey('SAMLRequest', $parsedQuery);
             $this->assertArrayHasKey('RelayState', $parsedQuery);
             $this->assertEquals($parsedQuery['RelayState'], $relayState);
@@ -1490,13 +1490,13 @@ class AuthTest extends \PHPUnit\Framework\TestCase
             // Do not ever get here
             $this->assertFalse(true);
         } catch (Exception $e) {
-            $this->assertContains('Cannot modify header information', $e->getMessage());
+            $this->assertStringContainsString('Cannot modify header information', $e->getMessage());
             $trace = $e->getTrace();
             $targetUrl = getUrlFromRedirect($trace);
             $parsedQuery = getParamsFromUrl($targetUrl);
 
             $sloUrl = $this->_settingsInfo['idp']['singleLogoutService']['url'];
-            $this->assertContains($sloUrl, $targetUrl);
+            $this->assertStringContainsString($sloUrl, $targetUrl);
             $this->assertArrayHasKey('SAMLRequest', $parsedQuery);
         }
     }
@@ -1523,13 +1523,13 @@ class AuthTest extends \PHPUnit\Framework\TestCase
             // Do not ever get here
             $this->assertFalse(true);
         } catch (Exception $e) {
-            $this->assertContains('Cannot modify header information', $e->getMessage());
+            $this->assertStringContainsString('Cannot modify header information', $e->getMessage());
             $trace = $e->getTrace();
             $targetUrl = getUrlFromRedirect($trace);
             $parsedQuery = getParamsFromUrl($targetUrl);
 
             $sloUrl = $this->_settingsInfo['idp']['singleLogoutService']['url'];
-            $this->assertContains($sloUrl, $targetUrl);
+            $this->assertStringContainsString($sloUrl, $targetUrl);
             $this->assertArrayHasKey('SAMLRequest', $parsedQuery);
 
             $logoutRequest = gzinflate(base64_decode($parsedQuery['SAMLRequest']));
@@ -1564,13 +1564,13 @@ class AuthTest extends \PHPUnit\Framework\TestCase
             // Do not ever get here
             $this->assertFalse(true);
         } catch (Exception $e) {
-            $this->assertContains('Cannot modify header information', $e->getMessage());
+            $this->assertStringContainsString('Cannot modify header information', $e->getMessage());
             $trace = $e->getTrace();
             $targetUrl = getUrlFromRedirect($trace);
             $parsedQuery = getParamsFromUrl($targetUrl);
 
             $sloUrl = $settingsInfo['idp']['singleLogoutService']['url'];
-            $this->assertContains($sloUrl, $targetUrl);
+            $this->assertStringContainsString($sloUrl, $targetUrl);
             $this->assertArrayHasKey('SAMLRequest', $parsedQuery);
             $this->assertArrayHasKey('RelayState', $parsedQuery);
             $this->assertArrayHasKey('SigAlg', $parsedQuery);
@@ -1600,7 +1600,7 @@ class AuthTest extends \PHPUnit\Framework\TestCase
             $auth->logout($returnTo);
             $this->fail('Error was not raised');
         } catch (Error $e) {
-            $this->assertContains('The IdP does not support Single Log Out', $e->getMessage());
+            $this->assertStringContainsString('The IdP does not support Single Log Out', $e->getMessage());
         }
     }
 
@@ -1632,7 +1632,7 @@ class AuthTest extends \PHPUnit\Framework\TestCase
             $auth->setStrict('a');
             $this->fail('Exception was not raised');
         } catch (Exception $e) {
-            $this->assertContains('Invalid value passed to setStrict()', $e->getMessage());
+            $this->assertStringContainsString('Invalid value passed to setStrict()', $e->getMessage());
         }
     }
 

--- a/tests/src/OneLogin/Saml2/AuthnRequestTest.php
+++ b/tests/src/OneLogin/Saml2/AuthnRequestTest.php
@@ -16,7 +16,7 @@ class AuthnRequestTest extends \PHPUnit\Framework\TestCase
     /**
      * Initializes the Test Suite
      */
-    public function setUp()
+    public function setUp() : void
     {
         $settingsDir = TEST_ROOT .'/settings/';
         include $settingsDir.'settings1.php';
@@ -36,13 +36,13 @@ class AuthnRequestTest extends \PHPUnit\Framework\TestCase
         $authnRequest = new AuthnRequest($this->_settings);
         $parameters = array('SAMLRequest' => $authnRequest->getRequest());
         $authUrl = Utils::redirect('http://idp.example.com/SSOService.php', $parameters, true);
-        $this->assertRegExp('#^http://idp\.example\.com\/SSOService\.php\?SAMLRequest=#', $authUrl);
+        $this->assertMatchesRegularExpression('#^http://idp\.example\.com\/SSOService\.php\?SAMLRequest=#', $authUrl);
         parse_str(parse_url($authUrl, PHP_URL_QUERY), $exploded);
         // parse_url already urldecode de params so is not required.
         $payload = $exploded['SAMLRequest'];
         $decoded = base64_decode($payload);
         $inflated = gzinflate($decoded);
-        $this->assertRegExp('#^<samlp:AuthnRequest#', $inflated);
+        $this->assertMatchesRegularExpression('#^<samlp:AuthnRequest#', $inflated);
     }
 
     /**
@@ -61,8 +61,8 @@ class AuthnRequestTest extends \PHPUnit\Framework\TestCase
         $encodedRequest = $authnRequest->getRequest();
         $decoded = base64_decode($encodedRequest);
         $request = gzinflate($decoded);
-        $this->assertContains('<samlp:RequestedAuthnContext Comparison="exact">', $request);
-        $this->assertContains('<saml:AuthnContextClassRef>urn:oasis:names:tc:SAML:2.0:ac:classes:PasswordProtectedTransport</saml:AuthnContextClassRef>', $request);
+        $this->assertStringContainsString('<samlp:RequestedAuthnContext Comparison="exact">', $request);
+        $this->assertStringContainsString('<saml:AuthnContextClassRef>urn:oasis:names:tc:SAML:2.0:ac:classes:PasswordProtectedTransport</saml:AuthnContextClassRef>', $request);
 
         $settingsInfo['security']['requestedAuthnContext']= true;
         $settings2 = new Settings($settingsInfo);
@@ -70,8 +70,8 @@ class AuthnRequestTest extends \PHPUnit\Framework\TestCase
         $encodedRequest2 = $authnRequest2->getRequest();
         $decoded2 = base64_decode($encodedRequest2);
         $request2 = gzinflate($decoded2);
-        $this->assertContains('<samlp:RequestedAuthnContext Comparison="exact">', $request2);
-        $this->assertContains('<saml:AuthnContextClassRef>urn:oasis:names:tc:SAML:2.0:ac:classes:PasswordProtectedTransport</saml:AuthnContextClassRef>', $request2);
+        $this->assertStringContainsString('<samlp:RequestedAuthnContext Comparison="exact">', $request2);
+        $this->assertStringContainsString('<saml:AuthnContextClassRef>urn:oasis:names:tc:SAML:2.0:ac:classes:PasswordProtectedTransport</saml:AuthnContextClassRef>', $request2);
 
         $settingsInfo['security']['requestedAuthnContext'] = false;
         $settings3 = new Settings($settingsInfo);
@@ -79,8 +79,8 @@ class AuthnRequestTest extends \PHPUnit\Framework\TestCase
         $encodedRequest3 = $authnRequest3->getRequest();
         $decoded3 = base64_decode($encodedRequest3);
         $request3 = gzinflate($decoded3);
-        $this->assertNotContains('<samlp:RequestedAuthnContext Comparison="exact">', $request3);
-        $this->assertNotContains('<saml:AuthnContextClassRef>urn:oasis:names:tc:SAML:2.0:ac:classes:PasswordProtectedTransport</saml:AuthnContextClassRef>', $request3);
+        $this->assertStringNotContainsString('<samlp:RequestedAuthnContext Comparison="exact">', $request3);
+        $this->assertStringNotContainsString('<saml:AuthnContextClassRef>urn:oasis:names:tc:SAML:2.0:ac:classes:PasswordProtectedTransport</saml:AuthnContextClassRef>', $request3);
 
         $settingsInfo['security']['requestedAuthnContext']= array('urn:oasis:names:tc:SAML:2.0:ac:classes:Password', 'urn:oasis:names:tc:SAML:2.0:ac:classes:X509');
         $settings4 = new Settings($settingsInfo);
@@ -88,10 +88,10 @@ class AuthnRequestTest extends \PHPUnit\Framework\TestCase
         $encodedRequest4 = $authnRequest4->getRequest();
         $decoded4 = base64_decode($encodedRequest4);
         $request4 = gzinflate($decoded4);
-        $this->assertContains('<samlp:RequestedAuthnContext Comparison="exact">', $request4);
-        $this->assertNotContains('<saml:AuthnContextClassRef>urn:oasis:names:tc:SAML:2.0:ac:classes:PasswordProtectedTransport</saml:AuthnContextClassRef>', $request4);
-        $this->assertContains('<saml:AuthnContextClassRef>urn:oasis:names:tc:SAML:2.0:ac:classes:Password</saml:AuthnContextClassRef>', $request4);
-        $this->assertContains('<saml:AuthnContextClassRef>urn:oasis:names:tc:SAML:2.0:ac:classes:X509</saml:AuthnContextClassRef>', $request4);
+        $this->assertStringContainsString('<samlp:RequestedAuthnContext Comparison="exact">', $request4);
+        $this->assertStringNotContainsString('<saml:AuthnContextClassRef>urn:oasis:names:tc:SAML:2.0:ac:classes:PasswordProtectedTransport</saml:AuthnContextClassRef>', $request4);
+        $this->assertStringContainsString('<saml:AuthnContextClassRef>urn:oasis:names:tc:SAML:2.0:ac:classes:Password</saml:AuthnContextClassRef>', $request4);
+        $this->assertStringContainsString('<saml:AuthnContextClassRef>urn:oasis:names:tc:SAML:2.0:ac:classes:X509</saml:AuthnContextClassRef>', $request4);
 
         $settingsInfo['security']['requestedAuthnContextComparison'] = 'minimum';
         $settings5 = new Settings($settingsInfo);
@@ -99,7 +99,7 @@ class AuthnRequestTest extends \PHPUnit\Framework\TestCase
         $encodedRequest5 = $authnRequest5->getRequest();
         $decoded5 = base64_decode($encodedRequest5);
         $request5 = gzinflate($decoded5);
-        $this->assertContains('<samlp:RequestedAuthnContext Comparison="minimum">', $request5);
+        $this->assertStringContainsString('<samlp:RequestedAuthnContext Comparison="minimum">', $request5);
 
         $settingsInfo['security']['requestedAuthnContextComparison'] = '';
         $settings6 = new Settings($settingsInfo);
@@ -107,7 +107,7 @@ class AuthnRequestTest extends \PHPUnit\Framework\TestCase
         $encodedRequest6 = $authnRequest6->getRequest();
         $decoded6 = base64_decode($encodedRequest6);
         $request6 = gzinflate($decoded6);
-        $this->assertContains('<samlp:RequestedAuthnContext >', $request6);
+        $this->assertStringContainsString('<samlp:RequestedAuthnContext >', $request6);
     }
 
     /**
@@ -126,19 +126,19 @@ class AuthnRequestTest extends \PHPUnit\Framework\TestCase
         $encodedRequest = $authnRequest->getRequest();
         $decoded = base64_decode($encodedRequest);
         $request = gzinflate($decoded);
-        $this->assertNotContains('ForceAuthn="true"', $request);
+        $this->assertStringNotContainsString('ForceAuthn="true"', $request);
 
         $authnRequest2 = new AuthnRequest($settings, false, false);
         $encodedRequest2 = $authnRequest2->getRequest();
         $decoded2 = base64_decode($encodedRequest2);
         $request2 = gzinflate($decoded2);
-        $this->assertNotContains('ForceAuthn="true"', $request2);
+        $this->assertStringNotContainsString('ForceAuthn="true"', $request2);
 
         $authnRequest3 = new AuthnRequest($settings, true, false);
         $encodedRequest3 = $authnRequest3->getRequest();
         $decoded3 = base64_decode($encodedRequest3);
         $request3 = gzinflate($decoded3);
-        $this->assertContains('ForceAuthn="true"', $request3);
+        $this->assertStringContainsString('ForceAuthn="true"', $request3);
     }
 
     /**
@@ -157,19 +157,19 @@ class AuthnRequestTest extends \PHPUnit\Framework\TestCase
         $encodedRequest = $authnRequest->getRequest();
         $decoded = base64_decode($encodedRequest);
         $request = gzinflate($decoded);
-        $this->assertNotContains('IsPassive="true"', $request);
+        $this->assertStringNotContainsString('IsPassive="true"', $request);
 
         $authnRequest2 = new AuthnRequest($settings, false, false);
         $encodedRequest2 = $authnRequest2->getRequest();
         $decoded2 = base64_decode($encodedRequest2);
         $request2 = gzinflate($decoded2);
-        $this->assertNotContains('IsPassive="true"', $request2);
+        $this->assertStringNotContainsString('IsPassive="true"', $request2);
 
         $authnRequest3 = new AuthnRequest($settings, false, true);
         $encodedRequest3 = $authnRequest3->getRequest();
         $decoded3 = base64_decode($encodedRequest3);
         $request3 = gzinflate($decoded3);
-        $this->assertContains('IsPassive="true"', $request3);
+        $this->assertStringContainsString('IsPassive="true"', $request3);
     }
 
     /**
@@ -188,19 +188,19 @@ class AuthnRequestTest extends \PHPUnit\Framework\TestCase
         $encodedRequest = $authnRequest->getRequest();
         $decoded = base64_decode($encodedRequest);
         $request = gzinflate($decoded);
-        $this->assertNotContains('<samlp:NameIDPolicy', $request);
+        $this->assertStringNotContainsString('<samlp:NameIDPolicy', $request);
 
         $authnRequest2 = new AuthnRequest($settings, false, false, true);
         $encodedRequest2 = $authnRequest2->getRequest();
         $decoded2 = base64_decode($encodedRequest2);
         $request2 = gzinflate($decoded2);
-        $this->assertContains('<samlp:NameIDPolicy', $request2);
+        $this->assertStringContainsString('<samlp:NameIDPolicy', $request2);
 
         $authnRequest3 = new AuthnRequest($settings);
         $encodedRequest3 = $authnRequest3->getRequest();
         $decoded3 = base64_decode($encodedRequest3);
         $request3 = gzinflate($decoded3);
-        $this->assertContains('<samlp:NameIDPolicy', $request3);
+        $this->assertStringContainsString('<samlp:NameIDPolicy', $request3);
     }
 
     /**
@@ -219,25 +219,25 @@ class AuthnRequestTest extends \PHPUnit\Framework\TestCase
         $encodedRequest = $authnRequest->getRequest();
         $decoded = base64_decode($encodedRequest);
         $request = gzinflate($decoded);
-        $this->assertNotContains('<saml:Subject', $request);
+        $this->assertStringNotContainsString('<saml:Subject', $request);
 
         $authnRequest2 = new AuthnRequest($settings, false, false, true, "testuser@example.com");
         $encodedRequest2 = $authnRequest2->getRequest();
         $decoded2 = base64_decode($encodedRequest2);
         $request2 = gzinflate($decoded2);
-        $this->assertContains('<saml:Subject', $request2);
-        $this->assertContains('Format="urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified">testuser@example.com</saml:NameID>', $request2);
+        $this->assertStringContainsString('<saml:Subject', $request2);
+        $this->assertStringContainsString('Format="urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified">testuser@example.com</saml:NameID>', $request2);
 
-        $this->assertContains('<saml:SubjectConfirmation Method="urn:oasis:names:tc:SAML:2.0:cm:bearer">', $request2);
+        $this->assertStringContainsString('<saml:SubjectConfirmation Method="urn:oasis:names:tc:SAML:2.0:cm:bearer">', $request2);
         $settingsInfo['sp']['NameIDFormat'] = "urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress";
         $settings = new Settings($settingsInfo);
         $authnRequest3 = new AuthnRequest($settings, false, false, true, "testuser@example.com");
         $encodedRequest3 = $authnRequest3->getRequest();
         $decoded3 = base64_decode($encodedRequest3);
         $request3 = gzinflate($decoded3);
-        $this->assertContains('<saml:Subject', $request3);
-        $this->assertContains('Format="urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress">testuser@example.com</saml:NameID>', $request3);
-        $this->assertContains('<saml:SubjectConfirmation Method="urn:oasis:names:tc:SAML:2.0:cm:bearer">', $request3);
+        $this->assertStringContainsString('<saml:Subject', $request3);
+        $this->assertStringContainsString('Format="urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress">testuser@example.com</saml:NameID>', $request3);
+        $this->assertStringContainsString('<saml:SubjectConfirmation Method="urn:oasis:names:tc:SAML:2.0:cm:bearer">', $request3);
     }
 
     /**
@@ -265,17 +265,17 @@ class AuthnRequestTest extends \PHPUnit\Framework\TestCase
         $authnRequest = new AuthnRequest($settings);
         $parameters = array('SAMLRequest' => $authnRequest->getRequest());
         $authUrl = Utils::redirect('http://idp.example.com/SSOService.php', $parameters, true);
-        $this->assertRegExp('#^http://idp\.example\.com\/SSOService\.php\?SAMLRequest=#', $authUrl);
+        $this->assertMatchesRegularExpression('#^http://idp\.example\.com\/SSOService\.php\?SAMLRequest=#', $authUrl);
         parse_str(parse_url($authUrl, PHP_URL_QUERY), $exploded);
         // parse_url already urldecode de params so is not required.
         $payload = $exploded['SAMLRequest'];
         $decoded = base64_decode($payload);
         $message = gzinflate($decoded);
-        $this->assertRegExp('#^<samlp:AuthnRequest#', $message);
-        $this->assertRegExp('#AssertionConsumerServiceURL="http://stuff.com/endpoints/endpoints/acs.php">#', $message);
-        $this->assertRegExp('#<saml:Issuer>http://stuff.com/endpoints/metadata.php</saml:Issuer>#', $message);
-        $this->assertRegExp('#Format="urn:oasis:names:tc:SAML:2.0:nameid-format:encrypted"#', $message);
-        $this->assertRegExp('#ProviderName="SP prueba"#', $message);
+        $this->assertMatchesRegularExpression('#^<samlp:AuthnRequest#', $message);
+        $this->assertMatchesRegularExpression('#AssertionConsumerServiceURL="http://stuff.com/endpoints/endpoints/acs.php">#', $message);
+        $this->assertMatchesRegularExpression('#<saml:Issuer>http://stuff.com/endpoints/metadata.php</saml:Issuer>#', $message);
+        $this->assertMatchesRegularExpression('#Format="urn:oasis:names:tc:SAML:2.0:nameid-format:encrypted"#', $message);
+        $this->assertMatchesRegularExpression('#ProviderName="SP prueba"#', $message);
     }
 
     /**
@@ -295,7 +295,7 @@ class AuthnRequestTest extends \PHPUnit\Framework\TestCase
         $payload = $authnRequest->getRequest();
         $decoded = base64_decode($payload);
         $decompressed = gzinflate($decoded);
-        $this->assertRegExp('#^<samlp:AuthnRequest#', $decompressed);
+        $this->assertMatchesRegularExpression('#^<samlp:AuthnRequest#', $decompressed);
     }
 
     /**
@@ -314,7 +314,7 @@ class AuthnRequestTest extends \PHPUnit\Framework\TestCase
         $authnRequest = new AuthnRequest($settings);
         $payload = $authnRequest->getRequest();
         $decoded = base64_decode($payload);
-        $this->assertRegExp('#^<samlp:AuthnRequest#', $decoded);
+        $this->assertMatchesRegularExpression('#^<samlp:AuthnRequest#', $decoded);
     }
 
     /**
@@ -335,7 +335,7 @@ class AuthnRequestTest extends \PHPUnit\Framework\TestCase
         $authnRequest = new AuthnRequest($settings);
         $payload = $authnRequest->getRequest(false);
         $decoded = base64_decode($payload);
-        $this->assertRegExp('#^<samlp:AuthnRequest#', $decoded);
+        $this->assertMatchesRegularExpression('#^<samlp:AuthnRequest#', $decoded);
 
         //Test that we can choose not to compress the request payload.
         $settingsDir = TEST_ROOT .'/settings/';
@@ -347,7 +347,7 @@ class AuthnRequestTest extends \PHPUnit\Framework\TestCase
         $payload = $authnRequest->getRequest(true);
         $decoded = base64_decode($payload);
         $decompressed = gzinflate($decoded);
-        $this->assertRegExp('#^<samlp:AuthnRequest#', $decompressed);
+        $this->assertMatchesRegularExpression('#^<samlp:AuthnRequest#', $decompressed);
     }
 
     /**
@@ -365,6 +365,6 @@ class AuthnRequestTest extends \PHPUnit\Framework\TestCase
         $authnRequest = new AuthnRequest($settings);
 
         $xml = $authnRequest->getXML();
-        $this->assertRegExp('#^<samlp:AuthnRequest#', $xml);
+        $this->assertMatchesRegularExpression('#^<samlp:AuthnRequest#', $xml);
     }
 }

--- a/tests/src/OneLogin/Saml2/LogoutRequestTest.php
+++ b/tests/src/OneLogin/Saml2/LogoutRequestTest.php
@@ -21,7 +21,7 @@ class LogoutRequestTest extends \PHPUnit\Framework\TestCase
     /**
      * Initializes the Test Suite
      */
-    public function setUp()
+    public function setUp() : void
     {
         $settingsDir = TEST_ROOT .'/settings/';
         include $settingsDir.'settings1.php';
@@ -48,14 +48,14 @@ class LogoutRequestTest extends \PHPUnit\Framework\TestCase
 
         $parameters = array('SAMLRequest' => $logoutRequest->getRequest());
         $logoutUrl = Utils::redirect('http://idp.example.com/SingleLogoutService.php', $parameters, true);
-        $this->assertRegExp('#^http://idp\.example\.com\/SingleLogoutService\.php\?SAMLRequest=#', $logoutUrl);
+        $this->assertMatchesRegularExpression('#^http://idp\.example\.com\/SingleLogoutService\.php\?SAMLRequest=#', $logoutUrl);
         parse_str(parse_url($logoutUrl, PHP_URL_QUERY), $exploded);
         // parse_url already urldecode de params so is not required.
         $payload = $exploded['SAMLRequest'];
         $decoded = base64_decode($payload);
         $inflated = gzinflate($decoded);
-        $this->assertRegExp('#^<samlp:LogoutRequest#', $inflated);
-        $this->assertRegExp('#<saml:EncryptedID>#', $inflated);
+        $this->assertMatchesRegularExpression('#^<samlp:LogoutRequest#', $inflated);
+        $this->assertMatchesRegularExpression('#<saml:EncryptedID>#', $inflated);
     }
 
     /**
@@ -76,13 +76,13 @@ class LogoutRequestTest extends \PHPUnit\Framework\TestCase
 
         $parameters = array('SAMLRequest' => $logoutRequest->getRequest());
         $logoutUrl = Utils::redirect('http://idp.example.com/SingleLogoutService.php', $parameters, true);
-        $this->assertRegExp('#^http://idp\.example\.com\/SingleLogoutService\.php\?SAMLRequest=#', $logoutUrl);
+        $this->assertMatchesRegularExpression('#^http://idp\.example\.com\/SingleLogoutService\.php\?SAMLRequest=#', $logoutUrl);
         parse_str(parse_url($logoutUrl, PHP_URL_QUERY), $exploded);
         // parse_url already urldecode de params so is not required.
         $payload = $exploded['SAMLRequest'];
         $decoded = base64_decode($payload);
         $inflated = gzinflate($decoded);
-        $this->assertRegExp('#<samlp:LogoutRequest#', $inflated);
+        $this->assertMatchesRegularExpression('#<samlp:LogoutRequest#', $inflated);
     }
 
     /**
@@ -102,16 +102,16 @@ class LogoutRequestTest extends \PHPUnit\Framework\TestCase
 
         $parameters = array('SAMLRequest' => $logoutRequest->getRequest());
         $logoutUrl = Utils::redirect('http://idp.example.com/SingleLogoutService.php', $parameters, true);
-        $this->assertRegExp('#^http://idp\.example\.com\/SingleLogoutService\.php\?SAMLRequest=#', $logoutUrl);
+        $this->assertMatchesRegularExpression('#^http://idp\.example\.com\/SingleLogoutService\.php\?SAMLRequest=#', $logoutUrl);
         parse_str(parse_url($logoutUrl, PHP_URL_QUERY), $exploded);
         // parse_url already urldecode de params so is not required.
         $payload = $exploded['SAMLRequest'];
         $decoded = base64_decode($payload);
         $inflated = gzinflate($decoded);
-        $this->assertRegExp('#^<samlp:LogoutRequest#', $inflated);
+        $this->assertMatchesRegularExpression('#^<samlp:LogoutRequest#', $inflated);
 
         $sessionIndexes = LogoutRequest::getSessionIndexes($inflated);
-        $this->assertInternalType('array', $sessionIndexes);
+        $this->assertIsArray($sessionIndexes);
         $this->assertEquals(array($sessionIndex), $sessionIndexes);
     }
 
@@ -133,13 +133,13 @@ class LogoutRequestTest extends \PHPUnit\Framework\TestCase
 
         $parameters = array('SAMLRequest' => $logoutRequest->getRequest());
         $logoutUrl = Utils::redirect('http://idp.example.com/SingleLogoutService.php', $parameters, true);
-        $this->assertRegExp('#^http://idp\.example\.com\/SingleLogoutService\.php\?SAMLRequest=#', $logoutUrl);
+        $this->assertMatchesRegularExpression('#^http://idp\.example\.com\/SingleLogoutService\.php\?SAMLRequest=#', $logoutUrl);
         parse_str(parse_url($logoutUrl, PHP_URL_QUERY), $exploded);
         // parse_url already urldecode de params so is not required.
         $payload = $exploded['SAMLRequest'];
         $decoded = base64_decode($payload);
         $inflated = gzinflate($decoded);
-        $this->assertRegExp('#^<samlp:LogoutRequest#', $inflated);
+        $this->assertMatchesRegularExpression('#^<samlp:LogoutRequest#', $inflated);
 
         $logoutNameId = LogoutRequest::getNameId($inflated);
         $this->assertEquals($nameId, $logoutNameId);
@@ -164,13 +164,13 @@ class LogoutRequestTest extends \PHPUnit\Framework\TestCase
         $logoutRequest = new LogoutRequest($settings, null, $nameId, null, null);
         $parameters = array('SAMLRequest' => $logoutRequest->getRequest());
         $logoutUrl = Utils::redirect('http://idp.example.com/SingleLogoutService.php', $parameters, true);
-        $this->assertRegExp('#^http://idp\.example\.com\/SingleLogoutService\.php\?SAMLRequest=#', $logoutUrl);
+        $this->assertMatchesRegularExpression('#^http://idp\.example\.com\/SingleLogoutService\.php\?SAMLRequest=#', $logoutUrl);
         parse_str(parse_url($logoutUrl, PHP_URL_QUERY), $exploded);
         // parse_url already urldecode de params so is not required.
         $payload = $exploded['SAMLRequest'];
         $decoded = base64_decode($payload);
         $inflated = gzinflate($decoded);
-        $this->assertRegExp('#^<samlp:LogoutRequest#', $inflated);
+        $this->assertMatchesRegularExpression('#^<samlp:LogoutRequest#', $inflated);
         $logoutNameId = LogoutRequest::getNameId($inflated);
         $this->assertEquals($nameId, $logoutNameId);
         $logoutNameIdData = LogoutRequest::getNameIdData($inflated);
@@ -193,13 +193,13 @@ class LogoutRequestTest extends \PHPUnit\Framework\TestCase
         $logoutRequest = new LogoutRequest($settings, null, $nameId, null, null);
         $parameters = array('SAMLRequest' => $logoutRequest->getRequest());
         $logoutUrl = Utils::redirect('http://idp.example.com/SingleLogoutService.php', $parameters, true);
-        $this->assertRegExp('#^http://idp\.example\.com\/SingleLogoutService\.php\?SAMLRequest=#', $logoutUrl);
+        $this->assertMatchesRegularExpression('#^http://idp\.example\.com\/SingleLogoutService\.php\?SAMLRequest=#', $logoutUrl);
         parse_str(parse_url($logoutUrl, PHP_URL_QUERY), $exploded);
         // parse_url already urldecode de params so is not required.
         $payload = $exploded['SAMLRequest'];
         $decoded = base64_decode($payload);
         $inflated = gzinflate($decoded);
-        $this->assertRegExp('#^<samlp:LogoutRequest#', $inflated);
+        $this->assertMatchesRegularExpression('#^<samlp:LogoutRequest#', $inflated);
         $logoutNameId = LogoutRequest::getNameId($inflated);
         $this->assertEquals($nameId, $logoutNameId);
         $logoutNameIdData = LogoutRequest::getNameIdData($inflated);
@@ -221,13 +221,13 @@ class LogoutRequestTest extends \PHPUnit\Framework\TestCase
         $logoutRequest = new LogoutRequest($settings, null, $nameId, null, $nameIdFormat, $nameIdNameQualifier);
         $parameters = array('SAMLRequest' => $logoutRequest->getRequest());
         $logoutUrl = Utils::redirect('http://idp.example.com/SingleLogoutService.php', $parameters, true);
-        $this->assertRegExp('#^http://idp\.example\.com\/SingleLogoutService\.php\?SAMLRequest=#', $logoutUrl);
+        $this->assertMatchesRegularExpression('#^http://idp\.example\.com\/SingleLogoutService\.php\?SAMLRequest=#', $logoutUrl);
         parse_str(parse_url($logoutUrl, PHP_URL_QUERY), $exploded);
         // parse_url already urldecode de params so is not required.
         $payload = $exploded['SAMLRequest'];
         $decoded = base64_decode($payload);
         $inflated = gzinflate($decoded);
-        $this->assertRegExp('#^<samlp:LogoutRequest#', $inflated);
+        $this->assertMatchesRegularExpression('#^<samlp:LogoutRequest#', $inflated);
         $logoutNameId = LogoutRequest::getNameId($inflated);
         $this->assertEquals($nameId, $logoutNameId);
         $logoutNameIdData = LogoutRequest::getNameIdData($inflated);
@@ -247,13 +247,13 @@ class LogoutRequestTest extends \PHPUnit\Framework\TestCase
 
         $parameters = array('SAMLRequest' => $logoutRequest->getRequest());
         $logoutUrl = Utils::redirect('http://idp.example.com/SingleLogoutService.php', $parameters, true);
-        $this->assertRegExp('#^http://idp\.example\.com\/SingleLogoutService\.php\?SAMLRequest=#', $logoutUrl);
+        $this->assertMatchesRegularExpression('#^http://idp\.example\.com\/SingleLogoutService\.php\?SAMLRequest=#', $logoutUrl);
         parse_str(parse_url($logoutUrl, PHP_URL_QUERY), $exploded);
         // parse_url already urldecode de params so is not required.
         $payload = $exploded['SAMLRequest'];
         $decoded = base64_decode($payload);
         $inflated = gzinflate($decoded);
-        $this->assertRegExp('#^<samlp:LogoutRequest#', $inflated);
+        $this->assertMatchesRegularExpression('#^<samlp:LogoutRequest#', $inflated);
     }
 
     /**
@@ -275,14 +275,14 @@ class LogoutRequestTest extends \PHPUnit\Framework\TestCase
 
         $parameters = array('SAMLRequest' => $logoutRequest->getRequest());
         $logoutUrl = Utils::redirect('http://idp.example.com/SingleLogoutService.php', $parameters, true);
-        $this->assertRegExp('#^http://idp\.example\.com\/SingleLogoutService\.php\?SAMLRequest=#', $logoutUrl);
+        $this->assertMatchesRegularExpression('#^http://idp\.example\.com\/SingleLogoutService\.php\?SAMLRequest=#', $logoutUrl);
         parse_str(parse_url($logoutUrl, PHP_URL_QUERY), $exploded);
         // parse_url already urldecode de params so is not required.
         $payload = $exploded['SAMLRequest'];
         $decoded = base64_decode($payload);
         $inflated = gzinflate($decoded);
-        $this->assertRegExp('#^<samlp:LogoutRequest#', $inflated);
-        $this->assertRegExp('#<saml:EncryptedID>#', $inflated);
+        $this->assertMatchesRegularExpression('#^<samlp:LogoutRequest#', $inflated);
+        $this->assertMatchesRegularExpression('#<saml:EncryptedID>#', $inflated);
     }
 
     /**
@@ -346,7 +346,7 @@ class LogoutRequestTest extends \PHPUnit\Framework\TestCase
             $nameIdData3 = LogoutRequest::getNameIdData($request2);
             $this->fail('Error was not raised');
         } catch (Error $e) {
-            $this->assertContains('Key is required in order to decrypt the NameID', $e->getMessage());
+            $this->assertStringContainsString('Key is required in order to decrypt the NameID', $e->getMessage());
         }
 
         $key = $this->_settings->getSPkey();
@@ -365,30 +365,30 @@ class LogoutRequestTest extends \PHPUnit\Framework\TestCase
             $nameIdData3 = LogoutRequest::getNameIdData($invRequest);
             $this->fail('ValidationError was not raised');
         } catch (ValidationError $e) {
-            $this->assertContains('NameID not found in the Logout Request', $e->getMessage());
+            $this->assertStringContainsString('NameID not found in the Logout Request', $e->getMessage());
         }
 
 
         $logoutRequest = new LogoutRequest($this->_settings, null, "ONELOGIN_1e442c129e1f822c8096086a1103c5ee2c7cae1c", null, Constants::NAMEID_PERSISTENT, $this->_settings->getIdPData()['entityId'], $this->_settings->getSPData()['entityId']);
         $logoutRequestStr = $logoutRequest->getXML();
-        $this->assertContains('ONELOGIN_1e442c129e1f822c8096086a1103c5ee2c7cae1c', $logoutRequestStr);
-        $this->assertContains('Format="'.Constants::NAMEID_PERSISTENT, $logoutRequestStr);
-        $this->assertContains('NameQualifier="'.$this->_settings->getIdPData()['entityId'], $logoutRequestStr);
-        $this->assertContains('SPNameQualifier="'.$this->_settings->getSPData()['entityId'], $logoutRequestStr);
+        $this->assertStringContainsString('ONELOGIN_1e442c129e1f822c8096086a1103c5ee2c7cae1c', $logoutRequestStr);
+        $this->assertStringContainsString('Format="'.Constants::NAMEID_PERSISTENT, $logoutRequestStr);
+        $this->assertStringContainsString('NameQualifier="'.$this->_settings->getIdPData()['entityId'], $logoutRequestStr);
+        $this->assertStringContainsString('SPNameQualifier="'.$this->_settings->getSPData()['entityId'], $logoutRequestStr);
 
         $logoutRequest2 = new LogoutRequest($this->_settings, null, "ONELOGIN_1e442c129e1f822c8096086a1103c5ee2c7cae1c", null, Constants::NAMEID_ENTITY, $this->_settings->getIdPData()['entityId'], $this->_settings->getSPData()['entityId']);
         $logoutRequestStr2 = $logoutRequest2->getXML();
-        $this->assertContains('ONELOGIN_1e442c129e1f822c8096086a1103c5ee2c7cae1c', $logoutRequestStr2);
-        $this->assertContains('Format="'.Constants::NAMEID_ENTITY, $logoutRequestStr2);
-        $this->assertNotContains('NameQualifier', $logoutRequestStr2);
-        $this->assertNotContains('SPNameQualifier', $logoutRequestStr2);
+        $this->assertStringContainsString('ONELOGIN_1e442c129e1f822c8096086a1103c5ee2c7cae1c', $logoutRequestStr2);
+        $this->assertStringContainsString('Format="'.Constants::NAMEID_ENTITY, $logoutRequestStr2);
+        $this->assertStringNotContainsString('NameQualifier', $logoutRequestStr2);
+        $this->assertStringNotContainsString('SPNameQualifier', $logoutRequestStr2);
 
         $logoutRequest3 = new LogoutRequest($this->_settings, null, "ONELOGIN_1e442c129e1f822c8096086a1103c5ee2c7cae1c", null, Constants::NAMEID_UNSPECIFIED);
         $logoutRequestStr3 = $logoutRequest3->getXML();
-        $this->assertContains('ONELOGIN_1e442c129e1f822c8096086a1103c5ee2c7cae1c', $logoutRequestStr3);
-        $this->assertNotContains('Format', $logoutRequestStr3);
-        $this->assertNotContains('NameQualifier', $logoutRequestStr3);
-        $this->assertNotContains('SPNameQualifier', $logoutRequestStr3);
+        $this->assertStringContainsString('ONELOGIN_1e442c129e1f822c8096086a1103c5ee2c7cae1c', $logoutRequestStr3);
+        $this->assertStringNotContainsString('Format', $logoutRequestStr3);
+        $this->assertStringNotContainsString('NameQualifier', $logoutRequestStr3);
+        $this->assertStringNotContainsString('SPNameQualifier', $logoutRequestStr3);
     }
 
     /**
@@ -408,7 +408,7 @@ class LogoutRequestTest extends \PHPUnit\Framework\TestCase
             $nameId2 = LogoutRequest::getNameId($request2);
             $this->fail('Error was not raised');
         } catch (Error $e) {
-            $this->assertContains('Key is required in order to decrypt the NameID', $e->getMessage());
+            $this->assertStringContainsString('Key is required in order to decrypt the NameID', $e->getMessage());
         }
         $key = $this->_settings->getSPkey();
         $nameId3 = LogoutRequest::getNameId($request2, $key);
@@ -478,7 +478,7 @@ class LogoutRequestTest extends \PHPUnit\Framework\TestCase
         $logoutRequest2 = new LogoutRequest($this->_settings, $encodedRequest);
 
         $this->assertFalse($logoutRequest2->isValid());
-        $this->assertContains('The LogoutRequest was received at', $logoutRequest2->getError());
+        $this->assertStringContainsString('The LogoutRequest was received at', $logoutRequest2->getError());
     }
 
     /**
@@ -505,7 +505,7 @@ class LogoutRequestTest extends \PHPUnit\Framework\TestCase
 
         $this->assertFalse($logoutRequest2->isValid());
         $errorException = $logoutRequest2->getErrorException();
-        $this->assertContains('The LogoutRequest was received at', $errorException->getMessage());
+        $this->assertStringContainsString('The LogoutRequest was received at', $errorException->getMessage());
         $this->assertEquals($errorException->getMessage(), $logoutRequest2->getError());
     }
 
@@ -531,7 +531,7 @@ class LogoutRequestTest extends \PHPUnit\Framework\TestCase
         $logoutRequest2 = new LogoutRequest($this->_settings, $encodedRequest);
 
         $this->assertFalse($logoutRequest2->isValid());
-        $this->assertContains('Invalid issuer in the Logout Request', $logoutRequest2->getError());
+        $this->assertStringContainsString('Invalid issuer in the Logout Request', $logoutRequest2->getError());
     }
 
     /**
@@ -592,7 +592,7 @@ class LogoutRequestTest extends \PHPUnit\Framework\TestCase
         $logoutRequest2 = new LogoutRequest($this->_settings, $encodedRequest);
 
         $this->assertFalse($logoutRequest2->isValid());
-        $this->assertContains('The LogoutRequest was received at', $logoutRequest2->getError());
+        $this->assertStringContainsString('The LogoutRequest was received at', $logoutRequest2->getError());
     }
 
     /**
@@ -668,7 +668,7 @@ class LogoutRequestTest extends \PHPUnit\Framework\TestCase
         $payload = $logoutRequest->getRequest();
         $decoded = base64_decode($payload);
         $decompressed = gzinflate($decoded);
-        $this->assertRegExp('#^<samlp:LogoutRequest#', $decompressed);
+        $this->assertMatchesRegularExpression('#^<samlp:LogoutRequest#', $decompressed);
 
     }
 
@@ -688,7 +688,7 @@ class LogoutRequestTest extends \PHPUnit\Framework\TestCase
         $logoutRequest = new LogoutRequest($settings);
         $payload = $logoutRequest->getRequest();
         $decoded = base64_decode($payload);
-        $this->assertRegExp('#^<samlp:LogoutRequest#', $decoded);
+        $this->assertMatchesRegularExpression('#^<samlp:LogoutRequest#', $decoded);
     }
 
     /**
@@ -709,7 +709,7 @@ class LogoutRequestTest extends \PHPUnit\Framework\TestCase
         $logoutRequest = new LogoutRequest($settings);
         $payload = $logoutRequest->getRequest(false);
         $decoded = base64_decode($payload);
-        $this->assertRegExp('#^<samlp:LogoutRequest#', $decoded);
+        $this->assertMatchesRegularExpression('#^<samlp:LogoutRequest#', $decoded);
 
         //Test that we can choose not to compress the request payload.
         $settingsDir = TEST_ROOT .'/settings/';
@@ -721,7 +721,7 @@ class LogoutRequestTest extends \PHPUnit\Framework\TestCase
         $payload = $logoutRequest->getRequest(true);
         $decoded = base64_decode($payload);
         $decompressed = gzinflate($decoded);
-        $this->assertRegExp('#^<samlp:LogoutRequest#', $decompressed);
+        $this->assertMatchesRegularExpression('#^<samlp:LogoutRequest#', $decompressed);
     }
 
     /**
@@ -751,7 +751,7 @@ class LogoutRequestTest extends \PHPUnit\Framework\TestCase
         $logoutRequest2 = new LogoutRequest($this->_settings, $encodedRequest);
 
         $this->assertFalse($logoutRequest2->isValid());
-        $this->assertContains('The LogoutRequest was received at', $logoutRequest2->getError());
+        $this->assertStringContainsString('The LogoutRequest was received at', $logoutRequest2->getError());
 
         $this->_settings->setStrict(false);
         $oldSignature = $_GET['Signature'];
@@ -760,7 +760,7 @@ class LogoutRequestTest extends \PHPUnit\Framework\TestCase
         $logoutRequest3 = new LogoutRequest($this->_settings, $encodedRequest);
 
         $this->assertFalse($logoutRequest3->isValid());
-        $this->assertContains('Signature validation failed. Logout Request rejected', $logoutRequest3->getError());
+        $this->assertStringContainsString('Signature validation failed. Logout Request rejected', $logoutRequest3->getError());
 
         $_GET['Signature'] = $oldSignature;
         $oldSigAlg = $_GET['SigAlg'];
@@ -772,7 +772,7 @@ class LogoutRequestTest extends \PHPUnit\Framework\TestCase
         $_GET['RelayState'] = 'http://example.com/relaystate';
 
         $this->assertFalse($logoutRequest3->isValid());
-        $this->assertContains('Signature validation failed. Logout Request rejected', $logoutRequest3->getError());
+        $this->assertStringContainsString('Signature validation failed. Logout Request rejected', $logoutRequest3->getError());
 
         $this->_settings->setStrict(true);
 
@@ -823,7 +823,7 @@ class LogoutRequestTest extends \PHPUnit\Framework\TestCase
         $logoutRequest7 = new LogoutRequest($settings2, $encodedRequest2);
 
         $this->assertFalse($logoutRequest7->isValid());
-        $this->assertContains('In order to validate the sign on the Logout Request, the x509cert of the IdP is required', $logoutRequest7->getError());
+        $this->assertStringContainsString('In order to validate the sign on the Logout Request, the x509cert of the IdP is required', $logoutRequest7->getError());
     }
 
     /**
@@ -870,11 +870,11 @@ class LogoutRequestTest extends \PHPUnit\Framework\TestCase
         $settings = new Settings($settingsInfo);
         $logoutRequest = new LogoutRequest($settings);
         $xml = $logoutRequest->getXML();
-        $this->assertRegExp('#^<samlp:LogoutRequest#', $xml);
+        $this->assertMatchesRegularExpression('#^<samlp:LogoutRequest#', $xml);
 
         $logoutRequestProcessed = new LogoutRequest($settings, base64_encode($xml));
         $xml2 = $logoutRequestProcessed->getXML();
-        $this->assertRegExp('#^<samlp:LogoutRequest#', $xml2);
+        $this->assertMatchesRegularExpression('#^<samlp:LogoutRequest#', $xml2);
     }
 
     /**
@@ -902,12 +902,12 @@ class LogoutRequestTest extends \PHPUnit\Framework\TestCase
      * Tests that the LogoutRequest throws an exception
      *
      * @covers OneLogin\Saml2\LogoutRequest::getID()
-     *
-     * @expectedException OneLogin\Saml2\Error
-     * @expectedExceptionMessage LogoutRequest could not be processed
      */
     public function testGetIDException()
     {
+        $this->expectException(Error::class);
+        $this->expectExceptionMessage('LogoutRequest could not be processed');
+
         $settingsDir = TEST_ROOT .'/settings/';
         include $settingsDir.'settings1.php';
         $settings = new Settings($settingsInfo);

--- a/tests/src/OneLogin/Saml2/LogoutResponseTest.php
+++ b/tests/src/OneLogin/Saml2/LogoutResponseTest.php
@@ -2,10 +2,11 @@
 
 namespace OneLogin\Saml2\Tests;
 
+use OneLogin\Saml2\Error;
+use OneLogin\Saml2\Utils;
+use OneLogin\Saml2\Settings;
 use OneLogin\Saml2\Constants;
 use OneLogin\Saml2\LogoutResponse;
-use OneLogin\Saml2\Settings;
-use OneLogin\Saml2\Utils;
 
 use DomDocument;
 
@@ -19,7 +20,7 @@ class LogoutResponseTest extends \PHPUnit\Framework\TestCase
     /**
      * Initializes the Test Suite
      */
-    public function setUp()
+    public function setUp() : void
     {
         $settingsDir = TEST_ROOT .'/settings/';
         include $settingsDir.'settings1.php';
@@ -37,7 +38,7 @@ class LogoutResponseTest extends \PHPUnit\Framework\TestCase
     {
         $message = file_get_contents(TEST_ROOT . '/data/logout_responses/logout_response_deflated.xml.base64');
         $response = new LogoutResponse($this->_settings, $message);
-        $this->assertRegExp('#<samlp:LogoutResponse#', $response->document->saveXML());
+        $this->assertMatchesRegularExpression('#<samlp:LogoutResponse#', $response->document->saveXML());
     }
 
     /**
@@ -55,13 +56,13 @@ class LogoutResponseTest extends \PHPUnit\Framework\TestCase
 
         $logoutUrl = Utils::redirect('http://idp.example.com/SingleLogoutService.php', $parameters, true);
 
-        $this->assertRegExp('#^http://idp\.example\.com\/SingleLogoutService\.php\?SAMLResponse=#', $logoutUrl);
+        $this->assertMatchesRegularExpression('#^http://idp\.example\.com\/SingleLogoutService\.php\?SAMLResponse=#', $logoutUrl);
         parse_str(parse_url($logoutUrl, PHP_URL_QUERY), $exploded);
         // parse_url already urldecode de params so is not required.
         $payload = $exploded['SAMLResponse'];
         $decoded = base64_decode($payload);
         $inflated = gzinflate($decoded);
-        $this->assertRegExp('#^<samlp:LogoutResponse#', $inflated);
+        $this->assertMatchesRegularExpression('#^<samlp:LogoutResponse#', $inflated);
     }
 
     /**
@@ -172,7 +173,7 @@ class LogoutResponseTest extends \PHPUnit\Framework\TestCase
         $this->assertTrue($response2->isValid());
 
         $this->assertFalse($response2->isValid($requestId));
-        $this->assertContains('The InResponseTo of the Logout Response:', $response2->getError());
+        $this->assertStringContainsString('The InResponseTo of the Logout Response:', $response2->getError());
     }
 
     /**
@@ -267,7 +268,7 @@ class LogoutResponseTest extends \PHPUnit\Framework\TestCase
         $this->_settings->setStrict(true);
         $response2 = new LogoutResponse($this->_settings, $message);
         $this->assertFalse($response2->isValid());
-        $this->assertContains('The LogoutResponse was received at', $response2->getError());
+        $this->assertStringContainsString('The LogoutResponse was received at', $response2->getError());
     }
 
     /**
@@ -293,7 +294,7 @@ class LogoutResponseTest extends \PHPUnit\Framework\TestCase
         $this->_settings->setStrict(true);
         $response2 = new LogoutResponse($this->_settings, $_GET['SAMLResponse']);
         $this->assertFalse($response2->isValid());
-        $this->assertContains('Invalid issuer in the Logout Response', $response2->getError());
+        $this->assertStringContainsString('Invalid issuer in the Logout Response', $response2->getError());
 
         $this->_settings->setStrict(false);
         $oldSignature = $_GET['Signature'];
@@ -407,7 +408,7 @@ class LogoutResponseTest extends \PHPUnit\Framework\TestCase
         $this->_settings->setStrict(true);
         $response2 = new LogoutResponse($this->_settings, $message);
         $this->assertFalse($response2->isValid());
-        $this->assertContains('The LogoutResponse was received at', $response2->getError());
+        $this->assertStringContainsString('The LogoutResponse was received at', $response2->getError());
 
         $plainMessage = gzinflate(base64_decode($message));
         $currentURL = Utils::getSelfURLNoQuery();
@@ -439,7 +440,7 @@ class LogoutResponseTest extends \PHPUnit\Framework\TestCase
         $payload = $logoutResponse->getResponse();
         $decoded = base64_decode($payload);
         $decompressed = gzinflate($decoded);
-        $this->assertRegExp('#^<samlp:LogoutResponse#', $decompressed);
+        $this->assertMatchesRegularExpression('#^<samlp:LogoutResponse#', $decompressed);
 
     }
 
@@ -463,7 +464,7 @@ class LogoutResponseTest extends \PHPUnit\Framework\TestCase
         $logoutResponse = new LogoutResponse($settings, $message);
         $payload = $logoutResponse->getResponse();
         $decoded = base64_decode($payload);
-        $this->assertRegExp('#^<samlp:LogoutResponse#', $decoded);
+        $this->assertMatchesRegularExpression('#^<samlp:LogoutResponse#', $decoded);
     }
 
     /**
@@ -486,7 +487,7 @@ class LogoutResponseTest extends \PHPUnit\Framework\TestCase
         $logoutResponse = new LogoutResponse($settings, $message);
         $payload = $logoutResponse->getResponse(false);
         $decoded = base64_decode($payload);
-        $this->assertRegExp('#^<samlp:LogoutResponse#', $decoded);
+        $this->assertMatchesRegularExpression('#^<samlp:LogoutResponse#', $decoded);
 
         $settingsDir = TEST_ROOT .'/settings/';
         include $settingsDir.'settings2.php';
@@ -496,7 +497,7 @@ class LogoutResponseTest extends \PHPUnit\Framework\TestCase
         $payload = $logoutResponse->getResponse(true);
         $decoded = base64_decode($payload);
         $decompressed = gzinflate($decoded);
-        $this->assertRegExp('#^<samlp:LogoutResponse#', $decompressed);
+        $this->assertMatchesRegularExpression('#^<samlp:LogoutResponse#', $decompressed);
     }
 
     /**
@@ -514,11 +515,11 @@ class LogoutResponseTest extends \PHPUnit\Framework\TestCase
         $logoutResponse = new LogoutResponse($settings);
         $logoutResponse->build('jhgvsadja');
         $xml = $logoutResponse->getXML();
-        $this->assertRegExp('#^<samlp:LogoutResponse#', $xml);
+        $this->assertMatchesRegularExpression('#^<samlp:LogoutResponse#', $xml);
 
         $processedLogoutResponse = new LogoutResponse($settings, base64_encode($xml));
         $xml2 = $processedLogoutResponse->getXML();
-        $this->assertRegExp('#^<samlp:LogoutResponse#', $xml2);
+        $this->assertMatchesRegularExpression('#^<samlp:LogoutResponse#', $xml2);
     }
 
     /**
@@ -548,12 +549,12 @@ class LogoutResponseTest extends \PHPUnit\Framework\TestCase
      * Tests that the LogoutRequest throws an exception
      *
      * @covers OneLogin\Saml2\LogoutRequest::getID()
-     *
-     * @expectedException OneLogin\Saml2\Error
-     * @expectedExceptionMessage LogoutResponse could not be processed
      */
     public function testGetIDException()
     {
+        $this->expectException(Error::class);
+        $this->expectExceptionMessage('LogoutRequest could not be processed');
+
         $settingsDir = TEST_ROOT .'/settings/';
         include $settingsDir.'settings1.php';
         $settings = new Settings($settingsInfo);

--- a/tests/src/OneLogin/Saml2/MetadataTest.php
+++ b/tests/src/OneLogin/Saml2/MetadataTest.php
@@ -37,21 +37,21 @@ class MetadataTest extends \PHPUnit\Framework\TestCase
 
         $this->assertNotEmpty($metadata);
 
-        $this->assertContains('<md:SPSSODescriptor', $metadata);
-        $this->assertContains('entityID="http://stuff.com/endpoints/metadata.php"', $metadata);
-        $this->assertContains('AuthnRequestsSigned="false"', $metadata);
-        $this->assertContains('WantAssertionsSigned="false"', $metadata);
+        $this->assertStringContainsString('<md:SPSSODescriptor', $metadata);
+        $this->assertStringContainsString('entityID="http://stuff.com/endpoints/metadata.php"', $metadata);
+        $this->assertStringContainsString('AuthnRequestsSigned="false"', $metadata);
+        $this->assertStringContainsString('WantAssertionsSigned="false"', $metadata);
 
-        $this->assertContains('<md:AssertionConsumerService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST"', $metadata);
-        $this->assertContains('Location="http://stuff.com/endpoints/endpoints/acs.php"', $metadata);
-        $this->assertContains('<md:SingleLogoutService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect"', $metadata);
-        $this->assertContains('Location="http://stuff.com/endpoints/endpoints/sls.php"', $metadata);
+        $this->assertStringContainsString('<md:AssertionConsumerService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST"', $metadata);
+        $this->assertStringContainsString('Location="http://stuff.com/endpoints/endpoints/acs.php"', $metadata);
+        $this->assertStringContainsString('<md:SingleLogoutService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect"', $metadata);
+        $this->assertStringContainsString('Location="http://stuff.com/endpoints/endpoints/sls.php"', $metadata);
 
-        $this->assertContains('<md:NameIDFormat>urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified</md:NameIDFormat>', $metadata);
+        $this->assertStringContainsString('<md:NameIDFormat>urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified</md:NameIDFormat>', $metadata);
 
-        $this->assertContains('<md:OrganizationName xml:lang="en-US">sp_test</md:OrganizationName>', $metadata);
-        $this->assertContains('<md:ContactPerson contactType="technical">', $metadata);
-        $this->assertContains('<md:GivenName>technical_name</md:GivenName>', $metadata);
+        $this->assertStringContainsString('<md:OrganizationName xml:lang="en-US">sp_test</md:OrganizationName>', $metadata);
+        $this->assertStringContainsString('<md:ContactPerson contactType="technical">', $metadata);
+        $this->assertStringContainsString('<md:GivenName>technical_name</md:GivenName>', $metadata);
 
         $security['authnRequestsSigned'] = true;
         $security['wantAssertionsSigned'] = true;
@@ -61,11 +61,11 @@ class MetadataTest extends \PHPUnit\Framework\TestCase
 
         $this->assertNotEmpty($metadata2);
 
-        $this->assertContains('AuthnRequestsSigned="true"', $metadata2);
-        $this->assertContains('WantAssertionsSigned="true"', $metadata2);
+        $this->assertStringContainsString('AuthnRequestsSigned="true"', $metadata2);
+        $this->assertStringContainsString('WantAssertionsSigned="true"', $metadata2);
 
-        $this->assertNotContains('<md:SingleLogoutService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect"', $metadata2);
-        $this->assertNotContains(' Location="http://stuff.com/endpoints/endpoints/sls.php"/>', $metadata2);
+        $this->assertStringNotContainsString('<md:SingleLogoutService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect"', $metadata2);
+        $this->assertStringNotContainsString(' Location="http://stuff.com/endpoints/endpoints/sls.php"/>', $metadata2);
     }
 
     /**
@@ -85,10 +85,10 @@ class MetadataTest extends \PHPUnit\Framework\TestCase
 
         $metadata = Metadata::builder($spData, $security['authnRequestsSigned'], $security['wantAssertionsSigned'], null, null, $contacts, $organization);
 
-        $this->assertContains('<md:ServiceName xml:lang="en">Service Name</md:ServiceName>', $metadata);
-        $this->assertContains('<md:ServiceDescription xml:lang="en">Service Description</md:ServiceDescription>', $metadata);
-        $this->assertContains('<md:RequestedAttribute Name="FirstName" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri" isRequired="true" />', $metadata);
-        $this->assertContains('<md:RequestedAttribute Name="LastName" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri" isRequired="true" />', $metadata);
+        $this->assertStringContainsString('<md:ServiceName xml:lang="en">Service Name</md:ServiceName>', $metadata);
+        $this->assertStringContainsString('<md:ServiceDescription xml:lang="en">Service Description</md:ServiceDescription>', $metadata);
+        $this->assertStringContainsString('<md:RequestedAttribute Name="FirstName" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri" isRequired="true" />', $metadata);
+        $this->assertStringContainsString('<md:RequestedAttribute Name="LastName" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri" isRequired="true" />', $metadata);
 
         $result = Utils::validateXML($metadata, 'saml-schema-metadata-2.0.xsd');
         $this->assertInstanceOf('DOMDocument', $result);
@@ -111,11 +111,11 @@ class MetadataTest extends \PHPUnit\Framework\TestCase
 
         $metadata = Metadata::builder($spData, $security['authnRequestsSigned'], $security['wantAssertionsSigned'], null, null, $contacts, $organization);
 
-        $this->assertContains('<md:ServiceName xml:lang="en">Service Name</md:ServiceName>', $metadata);
-        $this->assertContains('<md:ServiceDescription xml:lang="en">Service Description</md:ServiceDescription>', $metadata);
-        $this->assertContains('<md:RequestedAttribute Name="urn:oid:0.9.2342.19200300.100.1.1" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri" FriendlyName="uid" isRequired="true" />', $metadata);
-        $this->assertContains('<saml:AttributeValue xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion">userType</saml:AttributeValue>', $metadata);
-        $this->assertContains('<saml:AttributeValue xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion">admin</saml:AttributeValue>', $metadata);
+        $this->assertStringContainsString('<md:ServiceName xml:lang="en">Service Name</md:ServiceName>', $metadata);
+        $this->assertStringContainsString('<md:ServiceDescription xml:lang="en">Service Description</md:ServiceDescription>', $metadata);
+        $this->assertStringContainsString('<md:RequestedAttribute Name="urn:oid:0.9.2342.19200300.100.1.1" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri" FriendlyName="uid" isRequired="true" />', $metadata);
+        $this->assertStringContainsString('<saml:AttributeValue xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion">userType</saml:AttributeValue>', $metadata);
+        $this->assertStringContainsString('<saml:AttributeValue xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion">admin</saml:AttributeValue>', $metadata);
 
         $result = Utils::validateXML($metadata, 'saml-schema-metadata-2.0.xsd');
         $this->assertInstanceOf('DOMDocument', $result);
@@ -145,28 +145,28 @@ class MetadataTest extends \PHPUnit\Framework\TestCase
 
         $signedMetadata = Metadata::signMetadata($metadata, $key, $cert);
 
-        $this->assertContains('<md:SPSSODescriptor', $signedMetadata);
-        $this->assertContains('entityID="http://stuff.com/endpoints/metadata.php"', $signedMetadata);
-        $this->assertContains('AuthnRequestsSigned="false"', $signedMetadata);
-        $this->assertContains('WantAssertionsSigned="false"', $signedMetadata);
+        $this->assertStringContainsString('<md:SPSSODescriptor', $signedMetadata);
+        $this->assertStringContainsString('entityID="http://stuff.com/endpoints/metadata.php"', $signedMetadata);
+        $this->assertStringContainsString('AuthnRequestsSigned="false"', $signedMetadata);
+        $this->assertStringContainsString('WantAssertionsSigned="false"', $signedMetadata);
 
-        $this->assertContains('<md:AssertionConsumerService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST"', $signedMetadata);
-        $this->assertContains('Location="http://stuff.com/endpoints/endpoints/acs.php"', $signedMetadata);
-        $this->assertContains('<md:SingleLogoutService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect"', $signedMetadata);
-        $this->assertContains(' Location="http://stuff.com/endpoints/endpoints/sls.php"/>', $signedMetadata);
+        $this->assertStringContainsString('<md:AssertionConsumerService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST"', $signedMetadata);
+        $this->assertStringContainsString('Location="http://stuff.com/endpoints/endpoints/acs.php"', $signedMetadata);
+        $this->assertStringContainsString('<md:SingleLogoutService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect"', $signedMetadata);
+        $this->assertStringContainsString(' Location="http://stuff.com/endpoints/endpoints/sls.php"/>', $signedMetadata);
 
-        $this->assertContains('<md:NameIDFormat>urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified</md:NameIDFormat>', $signedMetadata);
+        $this->assertStringContainsString('<md:NameIDFormat>urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified</md:NameIDFormat>', $signedMetadata);
 
-        $this->assertContains('<ds:SignedInfo><ds:CanonicalizationMethod Algorithm="http://www.w3.org/2001/10/xml-exc-c14n#"/>', $signedMetadata);
-        $this->assertContains('<ds:SignatureMethod Algorithm="http://www.w3.org/2001/04/xmldsig-more#rsa-sha256"/>', $signedMetadata);
-        $this->assertContains('<ds:Reference', $signedMetadata);
-        $this->assertContains('<ds:KeyInfo><ds:X509Data><ds:X509Certificate>', $signedMetadata);
+        $this->assertStringContainsString('<ds:SignedInfo><ds:CanonicalizationMethod Algorithm="http://www.w3.org/2001/10/xml-exc-c14n#"/>', $signedMetadata);
+        $this->assertStringContainsString('<ds:SignatureMethod Algorithm="http://www.w3.org/2001/04/xmldsig-more#rsa-sha256"/>', $signedMetadata);
+        $this->assertStringContainsString('<ds:Reference', $signedMetadata);
+        $this->assertStringContainsString('<ds:KeyInfo><ds:X509Data><ds:X509Certificate>', $signedMetadata);
 
         try {
             $signedMetadata2 = Metadata::signMetadata('', $key, $cert);
             $this->fail('Exception was not raised');
-        } catch (Exception $e) {
-            $this->assertContains('Empty string supplied as input', $e->getMessage());
+        } catch (\Error $e) {
+            $this->assertStringContainsString('Argument #1 ($source) must not be empty', $e->getMessage());
         }
     }
 
@@ -192,8 +192,8 @@ class MetadataTest extends \PHPUnit\Framework\TestCase
 
         $signedMetadata = Metadata::signMetadata($metadata, $key, $cert);
 
-        $this->assertContains('<ds:SignatureMethod Algorithm="http://www.w3.org/2001/04/xmldsig-more#rsa-sha256"/>', $signedMetadata);
-        $this->assertContains('<ds:DigestMethod Algorithm="http://www.w3.org/2001/04/xmlenc#sha256"/>', $signedMetadata);
+        $this->assertStringContainsString('<ds:SignatureMethod Algorithm="http://www.w3.org/2001/04/xmldsig-more#rsa-sha256"/>', $signedMetadata);
+        $this->assertStringContainsString('<ds:DigestMethod Algorithm="http://www.w3.org/2001/04/xmlenc#sha256"/>', $signedMetadata);
     }
 
     /**
@@ -218,8 +218,8 @@ class MetadataTest extends \PHPUnit\Framework\TestCase
 
         $signedMetadata = Metadata::signMetadata($metadata, $key, $cert, XMLSecurityKey::RSA_SHA256, XMLSecurityDSig::SHA512);
 
-        $this->assertContains('<ds:SignatureMethod Algorithm="http://www.w3.org/2001/04/xmldsig-more#rsa-sha256"/>', $signedMetadata);
-        $this->assertContains('<ds:DigestMethod Algorithm="http://www.w3.org/2001/04/xmlenc#sha512"/>', $signedMetadata);
+        $this->assertStringContainsString('<ds:SignatureMethod Algorithm="http://www.w3.org/2001/04/xmldsig-more#rsa-sha256"/>', $signedMetadata);
+        $this->assertStringContainsString('<ds:DigestMethod Algorithm="http://www.w3.org/2001/04/xmlenc#sha512"/>', $signedMetadata);
     }
 
     /**
@@ -237,32 +237,32 @@ class MetadataTest extends \PHPUnit\Framework\TestCase
 
         $metadata = Metadata::builder($spData);
 
-        $this->assertNotContains('<md:KeyDescriptor use="signing"', $metadata);
-        $this->assertNotContains('<md:KeyDescriptor use="encryption"', $metadata);
+        $this->assertStringNotContainsString('<md:KeyDescriptor use="signing"', $metadata);
+        $this->assertStringNotContainsString('<md:KeyDescriptor use="encryption"', $metadata);
 
         $certPath = $settings->getCertPath();
         $cert = file_get_contents($certPath.'sp.crt');
 
         $metadataWithDescriptors = Metadata::addX509KeyDescriptors($metadata, $cert);
 
-        $this->assertContains('<md:KeyDescriptor use="signing"', $metadataWithDescriptors);
-        $this->assertContains('<md:KeyDescriptor use="encryption"', $metadataWithDescriptors);
+        $this->assertStringContainsString('<md:KeyDescriptor use="signing"', $metadataWithDescriptors);
+        $this->assertStringContainsString('<md:KeyDescriptor use="encryption"', $metadataWithDescriptors);
 
         $metadataWithDescriptors = Metadata::addX509KeyDescriptors($metadata, $cert, false);
 
-        $this->assertContains('<md:KeyDescriptor use="signing"', $metadataWithDescriptors);
-        $this->assertNotContains('<md:KeyDescriptor use="encryption"', $metadataWithDescriptors);
+        $this->assertStringContainsString('<md:KeyDescriptor use="signing"', $metadataWithDescriptors);
+        $this->assertStringNotContainsString('<md:KeyDescriptor use="encryption"', $metadataWithDescriptors);
 
         $metadataWithDescriptors = Metadata::addX509KeyDescriptors($metadata, $cert, 'foobar');
 
-        $this->assertContains('<md:KeyDescriptor use="signing"', $metadataWithDescriptors);
-        $this->assertNotContains('<md:KeyDescriptor use="encryption"', $metadataWithDescriptors);
+        $this->assertStringContainsString('<md:KeyDescriptor use="signing"', $metadataWithDescriptors);
+        $this->assertStringNotContainsString('<md:KeyDescriptor use="encryption"', $metadataWithDescriptors);
 
         try {
             $signedMetadata2 = Metadata::addX509KeyDescriptors('', $cert);
             $this->fail('Exception was not raised');
-        } catch (Exception $e) {
-            $this->assertContains('Error parsing metadata', $e->getMessage());
+        } catch (\Error $e) {
+            $this->assertStringContainsString('Argument #1 ($source) must not be empty', $e->getMessage());
         }
 
         libxml_use_internal_errors(true);
@@ -271,7 +271,7 @@ class MetadataTest extends \PHPUnit\Framework\TestCase
             $metadataWithDescriptors = Metadata::addX509KeyDescriptors($unparsedMetadata, $cert);
             $this->fail('Exception was not raised');
         } catch (Exception $e) {
-            $this->assertContains('Error parsing metadata', $e->getMessage());
+            $this->assertStringContainsString('Error parsing metadata', $e->getMessage());
         }
     }
 
@@ -291,8 +291,8 @@ class MetadataTest extends \PHPUnit\Framework\TestCase
 
         $metadata = Metadata::builder($spData);
 
-        $this->assertNotContains('<md:KeyDescriptor use="signing"', $metadata);
-        $this->assertNotContains('<md:KeyDescriptor use="encryption"', $metadata);
+        $this->assertStringNotContainsString('<md:KeyDescriptor use="signing"', $metadata);
+        $this->assertStringNotContainsString('<md:KeyDescriptor use="encryption"', $metadata);
 
         $certPath = $settings->getCertPath();
         $cert = file_get_contents($certPath.'sp.crt');

--- a/tests/src/OneLogin/Saml2/ResponseTest.php
+++ b/tests/src/OneLogin/Saml2/ResponseTest.php
@@ -20,7 +20,7 @@ class ResponseTest extends \PHPUnit\Framework\TestCase
     /**
      * Initializes the Test Suite
      */
-    public function setUp()
+    public function setUp() : void
     {
         $settingsDir = TEST_ROOT .'/settings/';
         include $settingsDir.'settings1.php';
@@ -136,7 +136,7 @@ class ResponseTest extends \PHPUnit\Framework\TestCase
         $xml3 = file_get_contents(TEST_ROOT . '/data/responses/valid_encrypted_assertion.xml.base64');
         $response3 = new Response($this->_settings, $xml3);
         $this->assertEquals('_68392312d490db6d355555cfbbd8ec95d746516f60', $response3->getNameId());
-        
+
         $xml4 = file_get_contents(TEST_ROOT . '/data/responses/invalids/no_nameid.xml.base64');
         $response4 = new Response($this->_settings, $xml4);
 
@@ -144,7 +144,7 @@ class ResponseTest extends \PHPUnit\Framework\TestCase
             $nameId4 = $response4->getNameId();
             $this->fail('ValidationError was not raised');
         } catch (ValidationError $e) {
-            $this->assertContains('NameID not found in the assertion of the Response', $e->getMessage());
+            $this->assertStringContainsString('NameID not found in the assertion of the Response', $e->getMessage());
         }
 
         $settingsDir = TEST_ROOT .'/settings/';
@@ -159,7 +159,7 @@ class ResponseTest extends \PHPUnit\Framework\TestCase
             $nameId5 = $response5->getNameId();
             $this->fail('ValidationError was not raised');
         } catch (ValidationError $e) {
-            $this->assertContains('NameID not found in the assertion of the Response', $e->getMessage());
+            $this->assertStringContainsString('NameID not found in the assertion of the Response', $e->getMessage());
         }
 
         $settingsInfo['security']['wantNameId'] = false;
@@ -177,7 +177,7 @@ class ResponseTest extends \PHPUnit\Framework\TestCase
             $nameId7 = $response7->getNameId();
             $this->fail('ValidationError was not raised');
         } catch (ValidationError $e) {
-            $this->assertContains('NameID not found in the assertion of the Response', $e->getMessage());
+            $this->assertStringContainsString('NameID not found in the assertion of the Response', $e->getMessage());
         }
 
         $xml5 = file_get_contents(TEST_ROOT . '/data/responses/wrong_spnamequalifier.xml.base64');
@@ -198,7 +198,7 @@ class ResponseTest extends \PHPUnit\Framework\TestCase
             $nameId10 = $response10->getNameId();
             $this->fail('ValidationError was not raised');
         } catch (ValidationError $e) {
-            $this->assertContains('The SPNameQualifier value mistmatch the SP entityID value.', $e->getMessage());
+            $this->assertStringContainsString('The SPNameQualifier value mistmatch the SP entityID value.', $e->getMessage());
         }
 
         $response11 = new Response($settings, $xml6);
@@ -207,7 +207,7 @@ class ResponseTest extends \PHPUnit\Framework\TestCase
             $nameId11 = $response11->getNameId();
             $this->fail('ValidationError was not raised');
         } catch (ValidationError $e) {
-            $this->assertContains('An empty NameID value found', $e->getMessage());
+            $this->assertStringContainsString('An empty NameID value found', $e->getMessage());
         }
     }
 
@@ -225,7 +225,7 @@ class ResponseTest extends \PHPUnit\Framework\TestCase
         $xml2 = file_get_contents(TEST_ROOT . '/data/responses/response_encrypted_nameid.xml.base64');
         $response2 = new Response($this->_settings, $xml2);
         $this->assertEquals('urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified', $response2->getNameIdFormat());
-    
+
         $xml3 = file_get_contents(TEST_ROOT . '/data/responses/valid_encrypted_assertion.xml.base64');
         $response3 = new Response($this->_settings, $xml3);
         $this->assertEquals('urn:oasis:names:tc:SAML:2.0:nameid-format:transient', $response3->getNameIdFormat());
@@ -237,15 +237,15 @@ class ResponseTest extends \PHPUnit\Framework\TestCase
             $nameId4 = $response4->getNameIdFormat();
             $this->fail('ValidationError was not raised');
         } catch (ValidationError $e) {
-            $this->assertContains('NameID not found in the assertion of the Response', $e->getMessage());
+            $this->assertStringContainsString('NameID not found in the assertion of the Response', $e->getMessage());
         }
     }
 
     /**
-    * Tests the getNameIdNameQualifier method of the Response
-    *
-    * @covers OneLogin\Saml2\Response::getNameIdNameQualifier
-    */
+     * Tests the getNameIdNameQualifier method of the Response
+     *
+     * @covers OneLogin\Saml2\Response::getNameIdNameQualifier
+     */
     public function testGetNameIdNameQualifier()
     {
         $xml = file_get_contents(TEST_ROOT . '/data/responses/response1.xml.base64');
@@ -263,15 +263,15 @@ class ResponseTest extends \PHPUnit\Framework\TestCase
             $nameId4 = $response4->getNameIdNameQualifier();
             $this->fail('ValidationError was not raised');
         } catch (ValidationError $e) {
-            $this->assertContains('NameID not found in the assertion of the Response', $e->getMessage());
+            $this->assertStringContainsString('NameID not found in the assertion of the Response', $e->getMessage());
         }
     }
 
     /**
-    * Tests the getNameIdSPNameQualifier method of the Response
-    *
-    * @covers OneLogin\Saml2\Response::getNameIdSPNameQualifier
-    */
+     * Tests the getNameIdSPNameQualifier method of the Response
+     *
+     * @covers OneLogin\Saml2\Response::getNameIdSPNameQualifier
+     */
     public function testGetNameIdSPNameQualifier()
     {
         $xml = file_get_contents(TEST_ROOT . '/data/responses/response1.xml.base64');
@@ -292,7 +292,7 @@ class ResponseTest extends \PHPUnit\Framework\TestCase
             $nameId5 = $response5->getNameIdSPNameQualifier();
             $this->fail('ValidationError was not raised');
         } catch (ValidationError $e) {
-            $this->assertContains('NameID not found in the assertion of the Response', $e->getMessage());
+            $this->assertStringContainsString('NameID not found in the assertion of the Response', $e->getMessage());
         }
     }
 
@@ -340,7 +340,7 @@ class ResponseTest extends \PHPUnit\Framework\TestCase
             $nameIdData4 = $response4->getNameIdData();
             $this->fail('ValidationError was not raised');
         } catch (ValidationError $e) {
-            $this->assertContains('NameID not found in the assertion of the Response', $e->getMessage());
+            $this->assertStringContainsString('NameID not found in the assertion of the Response', $e->getMessage());
         }
 
         $settingsDir = TEST_ROOT .'/settings/';
@@ -355,7 +355,7 @@ class ResponseTest extends \PHPUnit\Framework\TestCase
             $nameIdData5 = $response5->getNameIdData();
             $this->fail('ValidationError was not raised');
         } catch (ValidationError $e) {
-            $this->assertContains('NameID not found in the assertion of the Response', $e->getMessage());
+            $this->assertStringContainsString('NameID not found in the assertion of the Response', $e->getMessage());
         }
 
         $settingsInfo['security']['wantNameId'] = false;
@@ -373,7 +373,7 @@ class ResponseTest extends \PHPUnit\Framework\TestCase
             $nameIdData7 = $response7->getNameIdData();
             $this->fail('ValidationError was not raised');
         } catch (ValidationError $e) {
-            $this->assertContains('NameID not found in the assertion of the Response', $e->getMessage());
+            $this->assertStringContainsString('NameID not found in the assertion of the Response', $e->getMessage());
         }
 
         $xml5 = file_get_contents(TEST_ROOT . '/data/responses/wrong_spnamequalifier.xml.base64');
@@ -404,7 +404,7 @@ class ResponseTest extends \PHPUnit\Framework\TestCase
             $nameIdData10 = $response10->getNameIdData();
             $this->fail('ValidationError was not raised');
         } catch (ValidationError $e) {
-            $this->assertContains('The SPNameQualifier value mistmatch the SP entityID value.', $e->getMessage());
+            $this->assertStringContainsString('The SPNameQualifier value mistmatch the SP entityID value.', $e->getMessage());
         }
 
         $response11 = new Response($settings, $xml6);
@@ -412,7 +412,7 @@ class ResponseTest extends \PHPUnit\Framework\TestCase
             $nameIdData11 = $response11->getNameIdData();
             $this->fail('ValidationError was not raised');
         } catch (ValidationError $e) {
-            $this->assertContains('An empty NameID value found', $e->getMessage());
+            $this->assertStringContainsString('An empty NameID value found', $e->getMessage());
         }
     }
 
@@ -462,7 +462,7 @@ class ResponseTest extends \PHPUnit\Framework\TestCase
 
         $xmlEnc = file_get_contents(TEST_ROOT . '/data/responses/valid_encrypted_assertion.xml.base64');
         $responseEnc = new Response($this->_settings, $xmlEnc);
-        
+
         $response->checkStatus();
 
         $xml2 = file_get_contents(TEST_ROOT . '/data/responses/invalids/status_code_responder.xml.base64');
@@ -472,7 +472,7 @@ class ResponseTest extends \PHPUnit\Framework\TestCase
             $response2->checkStatus();
             $this->fail('ValidationError was not raised');
         } catch (ValidationError $e) {
-            $this->assertContains('The status code of the Response was not Success, was Responder', $e->getMessage());
+            $this->assertStringContainsString('The status code of the Response was not Success, was Responder', $e->getMessage());
         }
 
         $xml3 = file_get_contents(TEST_ROOT . '/data/responses/invalids/status_code_responer_and_msg.xml.base64');
@@ -481,7 +481,7 @@ class ResponseTest extends \PHPUnit\Framework\TestCase
             $response3->checkStatus();
             $this->fail('ValidationError was not raised');
         } catch (ValidationError $e) {
-            $this->assertContains('The status code of the Response was not Success, was Responder -> something_is_wrong', $e->getMessage());
+            $this->assertStringContainsString('The status code of the Response was not Success, was Responder -> something_is_wrong', $e->getMessage());
         }
     }
 
@@ -569,7 +569,7 @@ class ResponseTest extends \PHPUnit\Framework\TestCase
             $issuers = $response5->getIssuers();
             $this->fail('ValidationError was not raised');
         } catch (ValidationError $e) {
-            $this->assertContains('Issuer of the Assertion not found or multiple.', $e->getMessage());
+            $this->assertStringContainsString('Issuer of the Assertion not found or multiple.', $e->getMessage());
         }
     }
 
@@ -629,7 +629,7 @@ class ResponseTest extends \PHPUnit\Framework\TestCase
             $attrs = $response4->getAttributes();
             $this->fail('ValidationError was not raised');
         } catch (ValidationError $e) {
-            $this->assertContains('Found an Attribute element with duplicated Name', $e->getMessage());
+            $this->assertStringContainsString('Found an Attribute element with duplicated Name', $e->getMessage());
         }
 
         $settingsDir = TEST_ROOT .'/settings/';
@@ -674,7 +674,7 @@ class ResponseTest extends \PHPUnit\Framework\TestCase
             $attrs = $response4->getAttributesWithFriendlyName();
             $this->fail('OneLogin\Saml2\ValidationError was not raised');
         } catch (ValidationError $e) {
-            $this->assertContains('Found an Attribute element with duplicated FriendlyName', $e->getMessage());
+            $this->assertStringContainsString('Found an Attribute element with duplicated FriendlyName', $e->getMessage());
         }
     }
 
@@ -811,7 +811,7 @@ class ResponseTest extends \PHPUnit\Framework\TestCase
         $response = new Response($this->_settings, $xml);
 
         $this->assertEquals(1290203857, $response->getSessionNotOnOrAfter());
-        
+
         // An assertion that do not specified Session timeout should return NULL
         $xml2 = file_get_contents(TEST_ROOT . '/data/responses/response2.xml.base64');
         $response2 = new Response($this->_settings, $xml2);
@@ -1060,7 +1060,7 @@ class ResponseTest extends \PHPUnit\Framework\TestCase
         $response2 = new Response($this->_settings, $xml);
 
         $this->assertFalse($response2->isValid());
-        $this->assertContains('The response was received at', $response2->getError());
+        $this->assertStringContainsString('The response was received at', $response2->getError());
 
         // Empty Destination
         $xml2 = file_get_contents(TEST_ROOT . '/data/responses/invalids/empty_destination.xml.base64');
@@ -1084,7 +1084,7 @@ class ResponseTest extends \PHPUnit\Framework\TestCase
         $settings2 = new Settings($settingsInfo);
         $response6 = new Response($settings2, $xml5);
         $this->assertFalse($response6->isValid());
-        $this->assertContains('The response was received at', $response6->getError());
+        $this->assertStringContainsString('The response was received at', $response6->getError());
         unset($settingsInfo['strict']);
         unset($settingsInfo['security']['destinationStrictlyMatches']);
         unset($_SERVER['HTTP_HOST']);
@@ -1329,19 +1329,19 @@ class ResponseTest extends \PHPUnit\Framework\TestCase
 
         $response2 = new Response($this->_settings, $message);
         $response2->isValid($requestId);
-        $this->assertContains('The InResponseTo of the Response', $response2->getError());
-        
+        $this->assertStringContainsString('The InResponseTo of the Response', $response2->getError());
+
         $validRequestId = '_57bcbf70-7b1f-012e-c821-782bcb13bb38';
         $response2->isValid($validRequestId);
-        $this->assertContains('No Signature found. SAML Response rejected', $response2->getError());
+        $this->assertStringContainsString('No Signature found. SAML Response rejected', $response2->getError());
     }
 
     /**
-    * Tests the isValid method of the Response class
-    * Case Invalid Response, Unexpected InResponseTo
-    *
-    * @covers OneLogin\Saml2\Response::isValid
-    */
+     * Tests the isValid method of the Response class
+     * Case Invalid Response, Unexpected InResponseTo
+     *
+     * @covers OneLogin\Saml2\Response::isValid
+     */
     public function testIsInValidUnexpectedInResponseTo()
     {
         $xml = file_get_contents(TEST_ROOT . '/data/responses/unsigned_response.xml.base64');
@@ -1359,14 +1359,14 @@ class ResponseTest extends \PHPUnit\Framework\TestCase
         $response->isValid();
         $this->assertEquals('The Response has an InResponseTo attribute: '.$inResponseTo.' while no InResponseTo was expected', $response->getError());
         $response->isValid($inResponseTo);
-        $this->assertContains('No Signature found. SAML Response rejected', $response->getError());
+        $this->assertStringContainsString('No Signature found. SAML Response rejected', $response->getError());
     }
     /**
-    * Tests the isValid method of the Response class
-    * Case Invalid Response, No InResponseTo
-    *
-    * @covers OneLogin\Saml2\Response::isValid
-    */
+     * Tests the isValid method of the Response class
+     * Case Invalid Response, No InResponseTo
+     *
+     * @covers OneLogin\Saml2\Response::isValid
+     */
     public function testIsInValidNoInResponseTo()
     {
         $xml = file_get_contents(TEST_ROOT . '/data/responses/invalids/invalid_unpaired_inresponsesto.xml.base64');
@@ -1385,7 +1385,7 @@ class ResponseTest extends \PHPUnit\Framework\TestCase
         $inResponseTo = "_57bcbf70-7b1f-012e-c821-782bcb13bb38";
 
         $response->isValid();
-        $this->assertContains('No Signature found. SAML Response rejected', $response->getError());
+        $this->assertStringContainsString('No Signature found. SAML Response rejected', $response->getError());
 
         $response->isValid($inResponseTo);
         $this->assertEquals('No InResponseTo at the Response, but it was provided the requestId related to the AuthNRequest sent by the SP: '.$inResponseTo, $response->getError());
@@ -1412,20 +1412,20 @@ class ResponseTest extends \PHPUnit\Framework\TestCase
         $settings = new Settings($settingsInfo);
         $response = new Response($settings, $message);
         $response->isValid();
-        $this->assertContains('No Signature found. SAML Response rejected', $response->getError());
+        $this->assertStringContainsString('No Signature found. SAML Response rejected', $response->getError());
 
         $settingsInfo['security']['wantAssertionsSigned'] = true;
         $settings2 = new Settings($settingsInfo);
         $response2 = new Response($settings2, $message);
         $response2->isValid();
-        $this->assertContains('No Signature found. SAML Response rejected', $response2->getError());
+        $this->assertStringContainsString('No Signature found. SAML Response rejected', $response2->getError());
 
         $settingsInfo['strict'] = true;
         $settingsInfo['security']['wantAssertionsSigned'] = false;
         $settings3 = new Settings($settingsInfo);
         $response3 = new Response($settings3, $message);
         $response3->isValid();
-        $this->assertContains('No Signature found. SAML Response rejected', $response3->getError());
+        $this->assertStringContainsString('No Signature found. SAML Response rejected', $response3->getError());
 
         $settingsInfo['security']['wantAssertionsSigned'] = true;
         $settings4 = new Settings($settingsInfo);
@@ -1441,20 +1441,20 @@ class ResponseTest extends \PHPUnit\Framework\TestCase
         $settings5 = new Settings($settingsInfo);
         $response5 = new Response($settings5, $message);
         $response5->isValid();
-        $this->assertContains('No Signature found. SAML Response rejected', $response5->getError());
+        $this->assertStringContainsString('No Signature found. SAML Response rejected', $response5->getError());
 
         $settingsInfo['security']['wantMessagesSigned'] = true;
         $settings6 = new Settings($settingsInfo);
         $response6 = new Response($settings6, $message);
         $response6->isValid();
-        $this->assertContains('No Signature found. SAML Response rejected', $response6->getError());
+        $this->assertStringContainsString('No Signature found. SAML Response rejected', $response6->getError());
 
         $settingsInfo['strict'] = true;
         $settingsInfo['security']['wantMessagesSigned'] = false;
         $settings7 = new Settings($settingsInfo);
         $response7 = new Response($settings7, $message);
         $response7->isValid();
-        $this->assertContains('No Signature found. SAML Response rejected', $response7->getError());
+        $this->assertStringContainsString('No Signature found. SAML Response rejected', $response7->getError());
 
         $settingsInfo['security']['wantMessagesSigned'] = true;
         $settings8 = new Settings($settingsInfo);
@@ -1485,14 +1485,14 @@ class ResponseTest extends \PHPUnit\Framework\TestCase
         $settings = new Settings($settingsInfo);
         $response = new Response($settings, $message);
         $response->isValid();
-        $this->assertContains('No Signature found. SAML Response rejected', $response->getError());
+        $this->assertStringContainsString('No Signature found. SAML Response rejected', $response->getError());
 
         $settingsInfo['strict'] = true;
         $settingsInfo['security']['wantAssertionsEncrypted'] = false;
         $settings = new Settings($settingsInfo);
         $response2 = new Response($settings, $message);
         $response2->isValid();
-        $this->assertContains('No Signature found. SAML Response rejected', $response2->getError());
+        $this->assertStringContainsString('No Signature found. SAML Response rejected', $response2->getError());
 
         $settingsInfo['security']['wantAssertionsEncrypted'] = true;
         $settings = new Settings($settingsInfo);
@@ -1500,14 +1500,14 @@ class ResponseTest extends \PHPUnit\Framework\TestCase
 
         $this->assertFalse($response3->isValid());
         $this->assertEquals('The assertion of the Response is not encrypted and the SP requires it', $response3->getError());
-        
+
         $settingsInfo['security']['wantAssertionsEncrypted'] = false;
         $settingsInfo['security']['wantNameIdEncrypted'] = true;
         $settingsInfo['strict'] = false;
         $settings = new Settings($settingsInfo);
         $response4 = new Response($settings, $message);
         $response4->isValid();
-        $this->assertContains('No Signature found. SAML Response rejected', $response4->getError());
+        $this->assertStringContainsString('No Signature found. SAML Response rejected', $response4->getError());
 
         $settingsInfo['strict'] = true;
         $settings = new Settings($settingsInfo);
@@ -1570,7 +1570,7 @@ class ResponseTest extends \PHPUnit\Framework\TestCase
         $response = new Response($this->_settings, $xml);
 
         $response->isValid();
-        $this->assertContains('No Signature found. SAML Response rejected', $response->getError());
+        $this->assertStringContainsString('No Signature found. SAML Response rejected', $response->getError());
     }
 
     /**
@@ -1585,7 +1585,7 @@ class ResponseTest extends \PHPUnit\Framework\TestCase
         $response = new Response($this->_settings, $xml);
 
         $response->isValid();
-        $this->assertContains('No Signature found. SAML Response rejected', $response->getError());
+        $this->assertStringContainsString('No Signature found. SAML Response rejected', $response->getError());
     }
 
     /**
@@ -1661,7 +1661,7 @@ class ResponseTest extends \PHPUnit\Framework\TestCase
         $response4 = new Response($settings, $message4);
 
         $response4->isValid();
-        $this->assertContains('No Signature found. SAML Response rejected', $response4->getError());
+        $this->assertStringContainsString('No Signature found. SAML Response rejected', $response4->getError());
     }
 
     /**
@@ -1679,7 +1679,7 @@ class ResponseTest extends \PHPUnit\Framework\TestCase
         $xml = file_get_contents(TEST_ROOT . '/data/responses/signed_message_response.xml.base64');
         $response = new Response($this->_settings, $xml);
         $this->assertTrue($response->isValid());
-        
+
         $xml2 = file_get_contents(TEST_ROOT . '/data/responses/signed_assertion_response.xml.base64');
         $response2 = new Response($this->_settings, $xml2);
         $this->assertTrue($response2->isValid());
@@ -1738,7 +1738,7 @@ class ResponseTest extends \PHPUnit\Framework\TestCase
     {
         $settingsDir = TEST_ROOT .'/settings/';
         include $settingsDir.'settings6.php';
-        
+
         $settings = new Settings($settingsInfo);
 
         $xml = file_get_contents(TEST_ROOT . '/data/responses/signed_message_response.xml.base64');

--- a/tests/src/OneLogin/Saml2/SettingsTest.php
+++ b/tests/src/OneLogin/Saml2/SettingsTest.php
@@ -42,7 +42,7 @@ class SettingsTest extends \PHPUnit\Framework\TestCase
             $settings2 = new Settings($settingsInfo);
             $this->fail('Error was not raised');
         } catch (Error $e) {
-            $this->assertContains('Invalid array settings', $e->getMessage());
+            $this->assertStringContainsString('Invalid array settings', $e->getMessage());
         }
 
         include $settingsDir.'settings2.php';
@@ -220,9 +220,9 @@ class SettingsTest extends \PHPUnit\Framework\TestCase
             $settings = new Settings($settingsInfo);
             $this->fail('Error was not raised');
         } catch (Error $e) {
-             $expectedMessage = "Invalid array settings: 'compress'=>'requests' values must be true or false.";
-             $this->assertEquals($expectedMessage, $e->getMessage());
-             $requestsIsInvalid = true;
+            $expectedMessage = "Invalid array settings: 'compress'=>'requests' values must be true or false.";
+            $this->assertEquals($expectedMessage, $e->getMessage());
+            $requestsIsInvalid = true;
         }
 
         try {
@@ -233,9 +233,9 @@ class SettingsTest extends \PHPUnit\Framework\TestCase
             $settings = new Settings($settingsInfo);
             $this->fail('Error was not raised');
         } catch (Error $e) {
-             $expectedMessage = "Invalid array settings: 'compress'=>'responses' values must be true or false.";
-             $this->assertEquals($expectedMessage, $e->getMessage());
-             $responsesIsInvalid = true;
+            $expectedMessage = "Invalid array settings: 'compress'=>'responses' values must be true or false.";
+            $this->assertEquals($expectedMessage, $e->getMessage());
+            $responsesIsInvalid = true;
         }
 
         $this->assertTrue($requestsIsInvalid);
@@ -301,7 +301,7 @@ class SettingsTest extends \PHPUnit\Framework\TestCase
             $settings = new Settings($settingsInfo);
             $this->fail('Error was not raised');
         } catch (Error $e) {
-            $this->assertContains('Invalid array settings: invalid_syntax', $e->getMessage());
+            $this->assertStringContainsString('Invalid array settings: invalid_syntax', $e->getMessage());
         }
 
         $settingsInfo['strict'] = true;
@@ -309,8 +309,8 @@ class SettingsTest extends \PHPUnit\Framework\TestCase
             $settings = new Settings($settingsInfo);
             $this->fail('Error was not raised');
         } catch (Error $e) {
-            $this->assertContains('idp_not_found', $e->getMessage());
-            $this->assertContains('sp_not_found', $e->getMessage());
+            $this->assertStringContainsString('idp_not_found', $e->getMessage());
+            $this->assertStringContainsString('sp_not_found', $e->getMessage());
         }
 
         $settingsInfo['idp'] = array();
@@ -323,10 +323,10 @@ class SettingsTest extends \PHPUnit\Framework\TestCase
             $settings = new Settings($settingsInfo);
             $this->fail('Error was not raised');
         } catch (Error $e) {
-            $this->assertContains('idp_entityId_not_found', $e->getMessage());
-            $this->assertContains('idp_sso_not_found', $e->getMessage());
-            $this->assertContains('sp_entityId_not_found', $e->getMessage());
-            $this->assertContains('sp_acs_not_found', $e->getMessage());
+            $this->assertStringContainsString('idp_entityId_not_found', $e->getMessage());
+            $this->assertStringContainsString('idp_sso_not_found', $e->getMessage());
+            $this->assertStringContainsString('sp_entityId_not_found', $e->getMessage());
+            $this->assertStringContainsString('sp_acs_not_found', $e->getMessage());
         }
 
         $settingsInfo['idp']['entityID'] = 'entityId';
@@ -339,11 +339,11 @@ class SettingsTest extends \PHPUnit\Framework\TestCase
             $settings = new Settings($settingsInfo);
             $this->fail('Error was not raised');
         } catch (Error $e) {
-            $this->assertContains('idp_sso_url_invalid', $e->getMessage());
-            $this->assertContains('idp_slo_url_invalid', $e->getMessage());
-            $this->assertContains('idp_slo_response_url_invalid', $e->getMessage());
-            $this->assertContains('sp_acs_url_invalid', $e->getMessage());
-            $this->assertContains('sp_sls_url_invalid', $e->getMessage());
+            $this->assertStringContainsString('idp_sso_url_invalid', $e->getMessage());
+            $this->assertStringContainsString('idp_slo_url_invalid', $e->getMessage());
+            $this->assertStringContainsString('idp_slo_response_url_invalid', $e->getMessage());
+            $this->assertStringContainsString('sp_acs_url_invalid', $e->getMessage());
+            $this->assertStringContainsString('sp_sls_url_invalid', $e->getMessage());
         }
 
         $settingsInfo['security']['wantAssertionsSigned'] = true;
@@ -351,7 +351,7 @@ class SettingsTest extends \PHPUnit\Framework\TestCase
             $settings = new Settings($settingsInfo);
             $this->fail('Error was not raised');
         } catch (Error $e) {
-            $this->assertContains('idp_cert_or_fingerprint_not_found_and_required', $e->getMessage());
+            $this->assertStringContainsString('idp_cert_or_fingerprint_not_found_and_required', $e->getMessage());
         }
 
         $settingsInfo['security']['nameIdEncrypted'] = true;
@@ -359,7 +359,7 @@ class SettingsTest extends \PHPUnit\Framework\TestCase
             $settings = new Settings($settingsInfo);
             $this->fail('Error was not raised');
         } catch (Error $e) {
-            $this->assertContains('idp_cert_not_found_and_required', $e->getMessage());
+            $this->assertStringContainsString('idp_cert_not_found_and_required', $e->getMessage());
         }
 
         $settingsDir = TEST_ROOT .'/settings/';
@@ -386,9 +386,9 @@ class SettingsTest extends \PHPUnit\Framework\TestCase
             $settings = new Settings($settingsInfo);
             $this->fail('Error was not raised');
         } catch (Error $e) {
-            $this->assertContains('sp_signMetadata_invalid', $e->getMessage());
-            $this->assertContains('organization_not_enought_data', $e->getMessage());
-            $this->assertContains('contact_type_invalid', $e->getMessage());
+            $this->assertStringContainsString('sp_signMetadata_invalid', $e->getMessage());
+            $this->assertStringContainsString('organization_not_enought_data', $e->getMessage());
+            $this->assertStringContainsString('contact_type_invalid', $e->getMessage());
         }
 
         $settingsInfo['security']['signMetadata'] = ['privateKey' => file_get_contents(TEST_ROOT . '/data/customPath/certs/metadata.key')];
@@ -397,17 +397,17 @@ class SettingsTest extends \PHPUnit\Framework\TestCase
             $settings = new Settings($settingsInfo);
             $this->fail('Error was not raised');
         } catch (Error $e) {
-            $this->assertContains('sp_signMetadata_invalid', $e->getMessage());
-            $this->assertContains('organization_not_enought_data', $e->getMessage());
-            $this->assertContains('contact_type_invalid', $e->getMessage());
+            $this->assertStringContainsString('sp_signMetadata_invalid', $e->getMessage());
+            $this->assertStringContainsString('organization_not_enought_data', $e->getMessage());
+            $this->assertStringContainsString('contact_type_invalid', $e->getMessage());
         }
     }
 
     /**
-    * Tests the getIdPSSOurl method of the Settings class
-    *
-    * @covers OneLogin\Saml2\Settings::getIdPSSOurl
-    */
+     * Tests the getIdPSSOurl method of the Settings class
+     *
+     * @covers OneLogin\Saml2\Settings::getIdPSSOurl
+     */
     public function testGetIdPSSOurl()
     {
         $settingsDir = TEST_ROOT .'/settings/';
@@ -420,10 +420,10 @@ class SettingsTest extends \PHPUnit\Framework\TestCase
     }
 
     /**
-    * Tests the getIdPSLOurl method of the Settings class
-    *
-    * @covers OneLogin\Saml2\Settings::getIdPSLOurl
-    */
+     * Tests the getIdPSLOurl method of the Settings class
+     *
+     * @covers OneLogin\Saml2\Settings::getIdPSLOurl
+     */
     public function testGetIdPSLOurl()
     {
         $settingsDir = TEST_ROOT .'/settings/';
@@ -480,13 +480,13 @@ class SettingsTest extends \PHPUnit\Framework\TestCase
 
         $this->assertNotEmpty($metadata);
 
-        $this->assertContains('<md:SPSSODescriptor', $metadata);
-        $this->assertContains('entityID="http://stuff.com/endpoints/metadata.php"', $metadata);
-        $this->assertContains('AuthnRequestsSigned="false"', $metadata);
-        $this->assertContains('WantAssertionsSigned="false"', $metadata);
-        $this->assertContains('<md:AssertionConsumerService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="http://stuff.com/endpoints/endpoints/acs.php" index="1"/>', $metadata);
-        $this->assertContains('<md:SingleLogoutService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect" Location="http://stuff.com/endpoints/endpoints/sls.php"/>', $metadata);
-        $this->assertContains('<md:NameIDFormat>urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified</md:NameIDFormat>', $metadata);
+        $this->assertStringContainsString('<md:SPSSODescriptor', $metadata);
+        $this->assertStringContainsString('entityID="http://stuff.com/endpoints/metadata.php"', $metadata);
+        $this->assertStringContainsString('AuthnRequestsSigned="false"', $metadata);
+        $this->assertStringContainsString('WantAssertionsSigned="false"', $metadata);
+        $this->assertStringContainsString('<md:AssertionConsumerService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="http://stuff.com/endpoints/endpoints/acs.php" index="1"/>', $metadata);
+        $this->assertStringContainsString('<md:SingleLogoutService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect" Location="http://stuff.com/endpoints/endpoints/sls.php"/>', $metadata);
+        $this->assertStringContainsString('<md:NameIDFormat>urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified</md:NameIDFormat>', $metadata);
     }
 
     /**
@@ -565,11 +565,11 @@ class SettingsTest extends \PHPUnit\Framework\TestCase
     }
 
     /**
-    * Tests the getSPMetadata method of the OneLogin_Saml2_Settings
-    * Case ValidUntil CacheDuration
-    *
-    * @covers OneLogin\Saml2\Settings::getSPMetadata
-    */
+     * Tests the getSPMetadata method of the OneLogin_Saml2_Settings
+     * Case ValidUntil CacheDuration
+     *
+     * @covers OneLogin\Saml2\Settings::getSPMetadata
+     */
     public function testGetSPMetadataTiming()
     {
         $settingsDir = TEST_ROOT .'/settings/';
@@ -582,15 +582,15 @@ class SettingsTest extends \PHPUnit\Framework\TestCase
         $defaultCacheDuration = Metadata::TIME_CACHED;
 
         $metadata = $settings->getSPMetadata();
-        $this->assertContains('validUntil="'.$currentValidUntilStr.'"', $metadata);
-        $this->assertContains('cacheDuration="PT604800S"', $metadata);
+        $this->assertStringContainsString('validUntil="'.$currentValidUntilStr.'"', $metadata);
+        $this->assertStringContainsString('cacheDuration="PT604800S"', $metadata);
 
         $newValidUntil = 2524668343;
         $newValidUntilStr = gmdate('Y-m-d\TH:i:s\Z', $newValidUntil);
         $newCacheDuration = 1209600;
         $metadata2 = $settings->getSPMetadata(false, $newValidUntil, $newCacheDuration);
-        $this->assertContains('validUntil="'.$newValidUntilStr.'"', $metadata2);
-        $this->assertContains('cacheDuration="PT1209600S"', $metadata2);
+        $this->assertStringContainsString('validUntil="'.$newValidUntilStr.'"', $metadata2);
+        $this->assertStringContainsString('cacheDuration="PT1209600S"', $metadata2);
     }
 
     /**
@@ -614,18 +614,18 @@ class SettingsTest extends \PHPUnit\Framework\TestCase
 
         $this->assertNotEmpty($metadata);
 
-        $this->assertContains('<md:SPSSODescriptor', $metadata);
-        $this->assertContains('entityID="http://stuff.com/endpoints/metadata.php"', $metadata);
-        $this->assertContains('AuthnRequestsSigned="false"', $metadata);
-        $this->assertContains('WantAssertionsSigned="false"', $metadata);
-        $this->assertContains('<md:AssertionConsumerService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="http://stuff.com/endpoints/endpoints/acs.php" index="1"/>', $metadata);
-        $this->assertContains('<md:SingleLogoutService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect" Location="http://stuff.com/endpoints/endpoints/sls.php"/>', $metadata);
-        $this->assertContains('<md:NameIDFormat>urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified</md:NameIDFormat>', $metadata);
+        $this->assertStringContainsString('<md:SPSSODescriptor', $metadata);
+        $this->assertStringContainsString('entityID="http://stuff.com/endpoints/metadata.php"', $metadata);
+        $this->assertStringContainsString('AuthnRequestsSigned="false"', $metadata);
+        $this->assertStringContainsString('WantAssertionsSigned="false"', $metadata);
+        $this->assertStringContainsString('<md:AssertionConsumerService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="http://stuff.com/endpoints/endpoints/acs.php" index="1"/>', $metadata);
+        $this->assertStringContainsString('<md:SingleLogoutService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect" Location="http://stuff.com/endpoints/endpoints/sls.php"/>', $metadata);
+        $this->assertStringContainsString('<md:NameIDFormat>urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified</md:NameIDFormat>', $metadata);
 
-        $this->assertContains('<ds:SignedInfo><ds:CanonicalizationMethod Algorithm="http://www.w3.org/2001/10/xml-exc-c14n#"/>', $metadata);
-        $this->assertContains('<ds:SignatureMethod Algorithm="http://www.w3.org/2001/04/xmldsig-more#rsa-sha256"/>', $metadata);
-        $this->assertContains('<ds:Reference', $metadata);
-        $this->assertContains('<ds:KeyInfo><ds:X509Data><ds:X509Certificate>', $metadata);
+        $this->assertStringContainsString('<ds:SignedInfo><ds:CanonicalizationMethod Algorithm="http://www.w3.org/2001/10/xml-exc-c14n#"/>', $metadata);
+        $this->assertStringContainsString('<ds:SignatureMethod Algorithm="http://www.w3.org/2001/04/xmldsig-more#rsa-sha256"/>', $metadata);
+        $this->assertStringContainsString('<ds:Reference', $metadata);
+        $this->assertStringContainsString('<ds:KeyInfo><ds:X509Data><ds:X509Certificate>', $metadata);
 
 
         include $settingsDir.'settings2.php';
@@ -641,18 +641,18 @@ class SettingsTest extends \PHPUnit\Framework\TestCase
 
         $this->assertNotEmpty($metadata2);
 
-        $this->assertContains('<md:SPSSODescriptor', $metadata2);
-        $this->assertContains('entityID="http://stuff.com/endpoints/metadata.php"', $metadata2);
-        $this->assertContains('AuthnRequestsSigned="false"', $metadata2);
-        $this->assertContains('WantAssertionsSigned="false"', $metadata2);
-        $this->assertContains('<md:AssertionConsumerService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="http://stuff.com/endpoints/endpoints/acs.php" index="1"/>', $metadata2);
-        $this->assertContains('<md:SingleLogoutService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect" Location="http://stuff.com/endpoints/endpoints/sls.php"/>', $metadata2);
-        $this->assertContains('<md:NameIDFormat>urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified</md:NameIDFormat>', $metadata2);
+        $this->assertStringContainsString('<md:SPSSODescriptor', $metadata2);
+        $this->assertStringContainsString('entityID="http://stuff.com/endpoints/metadata.php"', $metadata2);
+        $this->assertStringContainsString('AuthnRequestsSigned="false"', $metadata2);
+        $this->assertStringContainsString('WantAssertionsSigned="false"', $metadata2);
+        $this->assertStringContainsString('<md:AssertionConsumerService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="http://stuff.com/endpoints/endpoints/acs.php" index="1"/>', $metadata2);
+        $this->assertStringContainsString('<md:SingleLogoutService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect" Location="http://stuff.com/endpoints/endpoints/sls.php"/>', $metadata2);
+        $this->assertStringContainsString('<md:NameIDFormat>urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified</md:NameIDFormat>', $metadata2);
 
-        $this->assertContains('<ds:SignedInfo><ds:CanonicalizationMethod Algorithm="http://www.w3.org/2001/10/xml-exc-c14n#"/>', $metadata2);
-        $this->assertContains('<ds:SignatureMethod Algorithm="http://www.w3.org/2001/04/xmldsig-more#rsa-sha256"/>', $metadata2);
-        $this->assertContains('<ds:Reference', $metadata2);
-        $this->assertContains('<ds:KeyInfo><ds:X509Data><ds:X509Certificate>', $metadata2);
+        $this->assertStringContainsString('<ds:SignedInfo><ds:CanonicalizationMethod Algorithm="http://www.w3.org/2001/10/xml-exc-c14n#"/>', $metadata2);
+        $this->assertStringContainsString('<ds:SignatureMethod Algorithm="http://www.w3.org/2001/04/xmldsig-more#rsa-sha256"/>', $metadata2);
+        $this->assertStringContainsString('<ds:Reference', $metadata2);
+        $this->assertStringContainsString('<ds:KeyInfo><ds:X509Data><ds:X509Certificate>', $metadata2);
 
         $cert = file_get_contents(TEST_ROOT . '/data/customPath/certs/metadata.crt');
         $settingsInfo['security']['signMetadata'] = [
@@ -663,19 +663,19 @@ class SettingsTest extends \PHPUnit\Framework\TestCase
         $metadata3 = $settings3->getSPMetadata();
 
         $this->assertNotEmpty($metadata3);
-        $this->assertContains('<md:SPSSODescriptor', $metadata3);
-        $this->assertContains('entityID="http://stuff.com/endpoints/metadata.php"', $metadata3);
-        $this->assertContains('AuthnRequestsSigned="false"', $metadata3);
-        $this->assertContains('WantAssertionsSigned="false"', $metadata3);
-        $this->assertContains('<md:AssertionConsumerService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="http://stuff.com/endpoints/endpoints/acs.php" index="1"/>', $metadata3);
-        $this->assertContains('<md:SingleLogoutService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect" Location="http://stuff.com/endpoints/endpoints/sls.php"/>', $metadata3);
-        $this->assertContains('<md:NameIDFormat>urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified</md:NameIDFormat>', $metadata3);
+        $this->assertStringContainsString('<md:SPSSODescriptor', $metadata3);
+        $this->assertStringContainsString('entityID="http://stuff.com/endpoints/metadata.php"', $metadata3);
+        $this->assertStringContainsString('AuthnRequestsSigned="false"', $metadata3);
+        $this->assertStringContainsString('WantAssertionsSigned="false"', $metadata3);
+        $this->assertStringContainsString('<md:AssertionConsumerService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="http://stuff.com/endpoints/endpoints/acs.php" index="1"/>', $metadata3);
+        $this->assertStringContainsString('<md:SingleLogoutService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect" Location="http://stuff.com/endpoints/endpoints/sls.php"/>', $metadata3);
+        $this->assertStringContainsString('<md:NameIDFormat>urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified</md:NameIDFormat>', $metadata3);
 
-        $this->assertContains('<ds:SignedInfo><ds:CanonicalizationMethod Algorithm="http://www.w3.org/2001/10/xml-exc-c14n#"/>', $metadata3);
-        $this->assertContains('<ds:SignatureMethod Algorithm="http://www.w3.org/2001/04/xmldsig-more#rsa-sha256"/>', $metadata3);
-        $this->assertContains('<ds:Reference', $metadata3);
-        $this->assertContains('<ds:KeyInfo><ds:X509Data><ds:X509Certificate>', $metadata3);
-        $this->assertContains(Utils::formatCert($cert, false), $metadata3);
+        $this->assertStringContainsString('<ds:SignedInfo><ds:CanonicalizationMethod Algorithm="http://www.w3.org/2001/10/xml-exc-c14n#"/>', $metadata3);
+        $this->assertStringContainsString('<ds:SignatureMethod Algorithm="http://www.w3.org/2001/04/xmldsig-more#rsa-sha256"/>', $metadata3);
+        $this->assertStringContainsString('<ds:Reference', $metadata3);
+        $this->assertStringContainsString('<ds:KeyInfo><ds:X509Data><ds:X509Certificate>', $metadata3);
+        $this->assertStringContainsString(Utils::formatCert($cert, false), $metadata3);
     }
 
     /**
@@ -699,7 +699,7 @@ class SettingsTest extends \PHPUnit\Framework\TestCase
             $metadata = $settings->getSPMetadata();
             $this->fail('Error was not raised');
         } catch (Error $e) {
-            $this->assertContains('sp_signMetadata_invalid', $e->getMessage());
+            $this->assertStringContainsString('sp_signMetadata_invalid', $e->getMessage());
         }
 
 
@@ -713,7 +713,7 @@ class SettingsTest extends \PHPUnit\Framework\TestCase
             $metadata = $settings->getSPMetadata();
             $this->fail('Error was not raised');
         } catch (Error $e) {
-            $this->assertContains('Private key file not found', $e->getMessage());
+            $this->assertStringContainsString('Private key file not found', $e->getMessage());
         }
 
         $settingsInfo['security']['signMetadata'] = array(
@@ -726,7 +726,7 @@ class SettingsTest extends \PHPUnit\Framework\TestCase
             $metadata = $settings->getSPMetadata();
             $this->fail('Error was not raised');
         } catch (Error $e) {
-            $this->assertContains('Public cert file not found', $e->getMessage());
+            $this->assertStringContainsString('Public cert file not found', $e->getMessage());
         }
     }
 
@@ -831,8 +831,8 @@ class SettingsTest extends \PHPUnit\Framework\TestCase
         try {
             $errors = $settings->validateMetadata($metadata);
             $this->fail('Exception was not raised');
-        } catch (Exception $e) {
-            $this->assertContains('Empty string supplied as input', $e->getMessage());
+        } catch (\Error $e) {
+            $this->assertStringContainsString('Argument #1 ($source) must not be empty', $e->getMessage());
         }
 
         $metadata = '<no xml>';
@@ -1097,7 +1097,7 @@ class SettingsTest extends \PHPUnit\Framework\TestCase
             $settings->setStrict('a');
             $this->fail('Exception was not raised');
         } catch (Exception $e) {
-            $this->assertContains('Invalid value passed to setStrict()', $e->getMessage());
+            $this->assertStringContainsString('Invalid value passed to setStrict()', $e->getMessage());
         }
     }
 

--- a/tests/src/OneLogin/Saml2/SignedResponseTest.php
+++ b/tests/src/OneLogin/Saml2/SignedResponseTest.php
@@ -15,7 +15,7 @@ class SignedResponseTest extends \PHPUnit\Framework\TestCase
     /**
      * Initializes the Test Suite
      */
-    public function setUp()
+    public function setUp() : void
     {
         $settingsDir = TEST_ROOT .'/settings/';
         include $settingsDir.'settings1.php';

--- a/tests/src/OneLogin/Saml2/UtilsTest.php
+++ b/tests/src/OneLogin/Saml2/UtilsTest.php
@@ -154,40 +154,40 @@ class UtilsTest extends \PHPUnit\Framework\TestCase
         $settings = new Settings($settingsInfo);
 
         $cert = $settingsInfo['idp']['x509cert'];
-        $this->assertNotContains('-----BEGIN CERTIFICATE-----', $cert);
-        $this->assertNotContains('-----END CERTIFICATE-----', $cert);
+        $this->assertStringNotContainsString('-----BEGIN CERTIFICATE-----', $cert);
+        $this->assertStringNotContainsString('-----END CERTIFICATE-----', $cert);
         $this->assertEquals(strlen($cert), 860);
 
         $formatedCert1 = Utils::formatCert($cert);
-        $this->assertContains('-----BEGIN CERTIFICATE-----', $formatedCert1);
-        $this->assertContains('-----END CERTIFICATE-----', $formatedCert1);
+        $this->assertStringContainsString('-----BEGIN CERTIFICATE-----', $formatedCert1);
+        $this->assertStringContainsString('-----END CERTIFICATE-----', $formatedCert1);
 
         $formatedCert2 = Utils::formatCert($cert, true);
         $this->assertEquals($formatedCert1, $formatedCert2);
 
 
         $formatedCert3 = Utils::formatCert($cert, false);
-        $this->assertNotContains('-----BEGIN CERTIFICATE-----', $formatedCert3);
-        $this->assertNotContains('-----END CERTIFICATE-----', $formatedCert3);
+        $this->assertStringNotContainsString('-----BEGIN CERTIFICATE-----', $formatedCert3);
+        $this->assertStringNotContainsString('-----END CERTIFICATE-----', $formatedCert3);
         $this->assertEquals(strlen($cert), 860);
 
 
         $cert2 = $settingsInfo['sp']['x509cert'];
-        $this->assertNotContains('-----BEGIN CERTIFICATE-----', $cert);
-        $this->assertNotContains('-----END CERTIFICATE-----', $cert);
+        $this->assertStringNotContainsString('-----BEGIN CERTIFICATE-----', $cert);
+        $this->assertStringNotContainsString('-----END CERTIFICATE-----', $cert);
         $this->assertEquals(strlen($cert), 860);
 
         $formatedCert4 = Utils::formatCert($cert);
-        $this->assertContains('-----BEGIN CERTIFICATE-----', $formatedCert4);
-        $this->assertContains('-----END CERTIFICATE-----', $formatedCert4);
+        $this->assertStringContainsString('-----BEGIN CERTIFICATE-----', $formatedCert4);
+        $this->assertStringContainsString('-----END CERTIFICATE-----', $formatedCert4);
 
         $formatedCert5 = Utils::formatCert($cert, true);
         $this->assertEquals($formatedCert4, $formatedCert5);
 
 
         $formatedCert6 = Utils::formatCert($cert, false);
-        $this->assertNotContains('-----BEGIN CERTIFICATE-----', $formatedCert6);
-        $this->assertNotContains('-----END CERTIFICATE-----', $formatedCert6);
+        $this->assertStringNotContainsString('-----BEGIN CERTIFICATE-----', $formatedCert6);
+        $this->assertStringNotContainsString('-----END CERTIFICATE-----', $formatedCert6);
         $this->assertEquals(strlen($cert2), 860);
 
     }
@@ -206,13 +206,13 @@ class UtilsTest extends \PHPUnit\Framework\TestCase
 
         $key = $settingsInfo['sp']['privateKey'];
 
-        $this->assertNotContains('-----BEGIN RSA PRIVATE KEY-----', $key);
-        $this->assertNotContains('-----END RSA PRIVATE KEY-----', $key);
+        $this->assertStringNotContainsString('-----BEGIN RSA PRIVATE KEY-----', $key);
+        $this->assertStringNotContainsString('-----END RSA PRIVATE KEY-----', $key);
         $this->assertEquals(strlen($key), 816);
 
         $formatedKey1 = Utils::formatPrivateKey($key);
-        $this->assertContains('-----BEGIN RSA PRIVATE KEY-----', $formatedKey1);
-        $this->assertContains('-----END RSA PRIVATE KEY-----', $formatedKey1);
+        $this->assertStringContainsString('-----BEGIN RSA PRIVATE KEY-----', $formatedKey1);
+        $this->assertStringContainsString('-----END RSA PRIVATE KEY-----', $formatedKey1);
 
         $formatedKey2 = Utils::formatPrivateKey($key, true);
         $this->assertEquals($formatedKey1, $formatedKey2);
@@ -220,8 +220,8 @@ class UtilsTest extends \PHPUnit\Framework\TestCase
 
         $formatedKey3 = Utils::formatPrivateKey($key, false);
 
-        $this->assertNotContains('-----BEGIN RSA PRIVATE KEY-----', $formatedKey3);
-        $this->assertNotContains('-----END RSA PRIVATE KEY-----', $formatedKey3);
+        $this->assertStringNotContainsString('-----BEGIN RSA PRIVATE KEY-----', $formatedKey3);
+        $this->assertStringNotContainsString('-----END RSA PRIVATE KEY-----', $formatedKey3);
         $this->assertEquals(strlen($key), 816);
     }
 
@@ -252,7 +252,7 @@ class UtilsTest extends \PHPUnit\Framework\TestCase
             $targetUrl4 = Utils::redirect($url4, array(), true);
             $this->fail('Exception was not raised');
         } catch (Exception $e) {
-            $this->assertContains('Redirect to invalid URL', $e->getMessage());
+            $this->assertStringContainsString('Redirect to invalid URL', $e->getMessage());
         }
 
         // Review parameter prefix
@@ -693,7 +693,7 @@ class UtilsTest extends \PHPUnit\Framework\TestCase
             $parsedDuration3 = Utils::parseDuration($invalidDuration);
             $this->fail('Exception was not raised');
         } catch (Exception $e) {
-            $this->assertContains('Invalid ISO 8601 duration', $e->getMessage());
+            $this->assertStringContainsString('Invalid ISO 8601 duration', $e->getMessage());
         }
 
         $newDuration = 'P1Y1M';
@@ -720,7 +720,7 @@ class UtilsTest extends \PHPUnit\Framework\TestCase
             Utils::parseSAML2Time('invalidSAMLTime');
             $this->fail('Exception was not raised');
         } catch (Exception $e) {
-            $this->assertContains('Invalid SAML2 timestamp passed', $e->getMessage());
+            $this->assertStringContainsString('Invalid SAML2 timestamp passed', $e->getMessage());
         }
 
         // Now test if toolkit supports miliseconds
@@ -743,7 +743,7 @@ class UtilsTest extends \PHPUnit\Framework\TestCase
             Utils::parseTime2SAML('invalidtime');
             $this->fail('Exception was not raised');
         } catch (Exception $e) {
-            $this->assertContains('Failed to parse time string', $e->getMessage());
+            $this->assertStringContainsString('Failed to parse time string', $e->getMessage());
         }
     }
 
@@ -852,14 +852,14 @@ class UtilsTest extends \PHPUnit\Framework\TestCase
         );
 
         $nameidExpectedEnc = '<saml:EncryptedID><xenc:EncryptedData xmlns:xenc="http://www.w3.org/2001/04/xmlenc#" xmlns:dsig="http://www.w3.org/2000/09/xmldsig#" Type="http://www.w3.org/2001/04/xmlenc#Element"><xenc:EncryptionMethod Algorithm="http://www.w3.org/2001/04/xmlenc#aes128-cbc"/><dsig:KeyInfo xmlns:dsig="http://www.w3.org/2000/09/xmldsig#"><xenc:EncryptedKey><xenc:EncryptionMethod Algorithm="http://www.w3.org/2001/04/xmlenc#rsa-1_5"/><xenc:CipherData><xenc:CipherValue>';
-        $this->assertContains($nameidExpectedEnc, $nameIdEnc);
+        $this->assertStringContainsString($nameidExpectedEnc, $nameIdEnc);
     }
 
     /**
-    * Tests the generateNameId method of the Utils
-    *
-    * @covers OneLogin\Saml2\Utils::generateNameId
-    */
+     * Tests the generateNameId method of the Utils
+     *
+     * @covers OneLogin\Saml2\Utils::generateNameId
+     */
     public function testGenerateNameIdWithoutFormat()
     {
         $nameIdValue = 'ONELOGIN_ce998811003f4e60f8b07a311dc641621379cfde';
@@ -910,7 +910,7 @@ class UtilsTest extends \PHPUnit\Framework\TestCase
         );
 
         $nameidExpectedEnc = '<saml:EncryptedID><xenc:EncryptedData xmlns:xenc="http://www.w3.org/2001/04/xmlenc#" xmlns:dsig="http://www.w3.org/2000/09/xmldsig#" Type="http://www.w3.org/2001/04/xmlenc#Element"><xenc:EncryptionMethod Algorithm="http://www.w3.org/2001/04/xmlenc#aes128-cbc"/><dsig:KeyInfo xmlns:dsig="http://www.w3.org/2000/09/xmldsig#"><xenc:EncryptedKey><xenc:EncryptionMethod Algorithm="http://www.w3.org/2001/04/xmlenc#rsa-1_5"/><xenc:CipherData><xenc:CipherValue>';
-        $this->assertContains($nameidExpectedEnc, $nameIdEnc);
+        $this->assertStringContainsString($nameidExpectedEnc, $nameIdEnc);
     }
 
     /**
@@ -1058,7 +1058,7 @@ class UtilsTest extends \PHPUnit\Framework\TestCase
             $res = Utils::decryptElement($encryptedNameIDNodes->item(0), $seckey);
             $this->fail('ValidationError was not raised');
         } catch (ValidationError $e) {
-            $this->assertContains('Algorithm mismatch between input key and key in message', $e->getMessage());
+            $this->assertStringContainsString('Algorithm mismatch between input key and key in message', $e->getMessage());
         }
 
         $key2 = file_get_contents(TEST_ROOT . '/data/misc/sp2.key');
@@ -1075,7 +1075,7 @@ class UtilsTest extends \PHPUnit\Framework\TestCase
             $res = Utils::decryptElement($encryptedData, $seckey3);
             $this->fail('ValidationError was not raised');
         } catch (ValidationError $e) {
-            $this->assertContains('Algorithm mismatch between input key and key used to encrypt  the symmetric key for the message', $e->getMessage());
+            $this->assertStringContainsString('Algorithm mismatch between input key and key used to encrypt  the symmetric key for the message', $e->getMessage());
         }
 
         $xmlNameIdEnc2 = base64_decode(file_get_contents(TEST_ROOT . '/data/responses/invalids/encrypted_nameID_without_EncMethod.xml.base64'));
@@ -1087,7 +1087,7 @@ class UtilsTest extends \PHPUnit\Framework\TestCase
             $res = Utils::decryptElement($encryptedData2, $seckey);
             $this->fail('Exception was not raised');
         } catch (Exception $e) {
-            $this->assertContains('Unable to locate algorithm for this Encrypted Key', $e->getMessage());
+            $this->assertStringContainsString('Unable to locate algorithm for this Encrypted Key', $e->getMessage());
         }
 
         $xmlNameIdEnc3 = base64_decode(file_get_contents(TEST_ROOT . '/data/responses/invalids/encrypted_nameID_without_keyinfo.xml.base64'));
@@ -1099,7 +1099,7 @@ class UtilsTest extends \PHPUnit\Framework\TestCase
             $res = Utils::decryptElement($encryptedData3, $seckey);
             $this->fail('ValidationError was not raised');
         } catch (ValidationError $e) {
-            $this->assertContains('Algorithm mismatch between input key and key in message', $e->getMessage());
+            $this->assertStringContainsString('Algorithm mismatch between input key and key in message', $e->getMessage());
         }
     }
 
@@ -1119,54 +1119,54 @@ class UtilsTest extends \PHPUnit\Framework\TestCase
 
         $xmlAuthn = base64_decode(file_get_contents(TEST_ROOT . '/data/requests/authn_request.xml.base64'));
         $xmlAuthnSigned = Utils::addSign($xmlAuthn, $key, $cert);
-        $this->assertContains('<ds:SignatureValue>', $xmlAuthnSigned);
-        $this->assertContains('<ds:SignatureMethod Algorithm="http://www.w3.org/2001/04/xmldsig-more#rsa-sha256"/>', $xmlAuthnSigned);
-        $this->assertContains('<ds:DigestMethod Algorithm="http://www.w3.org/2001/04/xmlenc#sha256"/>', $xmlAuthnSigned);
+        $this->assertStringContainsString('<ds:SignatureValue>', $xmlAuthnSigned);
+        $this->assertStringContainsString('<ds:SignatureMethod Algorithm="http://www.w3.org/2001/04/xmldsig-more#rsa-sha256"/>', $xmlAuthnSigned);
+        $this->assertStringContainsString('<ds:DigestMethod Algorithm="http://www.w3.org/2001/04/xmlenc#sha256"/>', $xmlAuthnSigned);
         $res = new DOMDocument();
         $res->loadXML($xmlAuthnSigned);
         $dsSignature = $res->firstChild->firstChild->nextSibling->nextSibling;
-        $this->assertContains('ds:Signature', $dsSignature->tagName);
+        $this->assertStringContainsString('ds:Signature', $dsSignature->tagName);
 
         $dom = new DOMDocument();
         $dom->loadXML($xmlAuthn);
         $xmlAuthnSigned2 = Utils::addSign($dom, $key, $cert, XMLSecurityKey::RSA_SHA384, XMLSecurityDSig::SHA512);
-        $this->assertContains('<ds:SignatureValue>', $xmlAuthnSigned2);
-        $this->assertContains('<ds:SignatureMethod Algorithm="http://www.w3.org/2001/04/xmldsig-more#rsa-sha384"/>', $xmlAuthnSigned2);
-        $this->assertContains('<ds:DigestMethod Algorithm="http://www.w3.org/2001/04/xmlenc#sha512"/>', $xmlAuthnSigned2);
+        $this->assertStringContainsString('<ds:SignatureValue>', $xmlAuthnSigned2);
+        $this->assertStringContainsString('<ds:SignatureMethod Algorithm="http://www.w3.org/2001/04/xmldsig-more#rsa-sha384"/>', $xmlAuthnSigned2);
+        $this->assertStringContainsString('<ds:DigestMethod Algorithm="http://www.w3.org/2001/04/xmlenc#sha512"/>', $xmlAuthnSigned2);
         $res2 = new DOMDocument();
         $res2->loadXML($xmlAuthnSigned2);
         $dsSignature2 = $res2->firstChild->firstChild->nextSibling->nextSibling;
-        $this->assertContains('ds:Signature', $dsSignature2->tagName);
+        $this->assertStringContainsString('ds:Signature', $dsSignature2->tagName);
 
         $xmlLogoutReq = base64_decode(file_get_contents(TEST_ROOT . '/data/logout_requests/logout_request.xml.base64'));
         $xmlLogoutReqSigned = Utils::addSign($xmlLogoutReq, $key, $cert, XMLSecurityKey::RSA_SHA256, XMLSecurityDSig::SHA512);
-        $this->assertContains('<ds:SignatureValue>', $xmlLogoutReqSigned);
-        $this->assertContains('<ds:SignatureMethod Algorithm="http://www.w3.org/2001/04/xmldsig-more#rsa-sha256"/>', $xmlLogoutReqSigned);
-        $this->assertContains('<ds:DigestMethod Algorithm="http://www.w3.org/2001/04/xmlenc#sha512"/>', $xmlLogoutReqSigned);
+        $this->assertStringContainsString('<ds:SignatureValue>', $xmlLogoutReqSigned);
+        $this->assertStringContainsString('<ds:SignatureMethod Algorithm="http://www.w3.org/2001/04/xmldsig-more#rsa-sha256"/>', $xmlLogoutReqSigned);
+        $this->assertStringContainsString('<ds:DigestMethod Algorithm="http://www.w3.org/2001/04/xmlenc#sha512"/>', $xmlLogoutReqSigned);
         $res3 = new DOMDocument();
         $res3->loadXML($xmlLogoutReqSigned);
         $dsSignature3 = $res3->firstChild->firstChild->nextSibling->nextSibling;
-        $this->assertContains('ds:Signature', $dsSignature3->tagName);
+        $this->assertStringContainsString('ds:Signature', $dsSignature3->tagName);
 
         $xmlLogoutRes = base64_decode(file_get_contents(TEST_ROOT . '/data/logout_responses/logout_response.xml.base64'));
         $xmlLogoutResSigned = Utils::addSign($xmlLogoutRes, $key, $cert, XMLSecurityKey::RSA_SHA256, XMLSecurityDSig::SHA512);
-        $this->assertContains('<ds:SignatureValue>', $xmlLogoutResSigned);
-        $this->assertContains('<ds:SignatureMethod Algorithm="http://www.w3.org/2001/04/xmldsig-more#rsa-sha256"/>', $xmlLogoutResSigned);
-        $this->assertContains('<ds:DigestMethod Algorithm="http://www.w3.org/2001/04/xmlenc#sha512"/>', $xmlLogoutResSigned);
+        $this->assertStringContainsString('<ds:SignatureValue>', $xmlLogoutResSigned);
+        $this->assertStringContainsString('<ds:SignatureMethod Algorithm="http://www.w3.org/2001/04/xmldsig-more#rsa-sha256"/>', $xmlLogoutResSigned);
+        $this->assertStringContainsString('<ds:DigestMethod Algorithm="http://www.w3.org/2001/04/xmlenc#sha512"/>', $xmlLogoutResSigned);
         $res4 = new DOMDocument();
         $res4->loadXML($xmlLogoutResSigned);
         $dsSignature4 = $res4->firstChild->firstChild->nextSibling->nextSibling;
-        $this->assertContains('ds:Signature', $dsSignature4->tagName);
+        $this->assertStringContainsString('ds:Signature', $dsSignature4->tagName);
 
         $xmlMetadata = file_get_contents(TEST_ROOT . '/data/metadata/metadata_settings1.xml');
         $xmlMetadataSigned = Utils::addSign($xmlMetadata, $key, $cert, XMLSecurityKey::RSA_SHA256, XMLSecurityDSig::SHA512);
-        $this->assertContains('<ds:SignatureValue>', $xmlMetadataSigned);
-        $this->assertContains('<ds:SignatureMethod Algorithm="http://www.w3.org/2001/04/xmldsig-more#rsa-sha256"/>', $xmlMetadataSigned);
-        $this->assertContains('<ds:DigestMethod Algorithm="http://www.w3.org/2001/04/xmlenc#sha512"/>', $xmlMetadataSigned);
+        $this->assertStringContainsString('<ds:SignatureValue>', $xmlMetadataSigned);
+        $this->assertStringContainsString('<ds:SignatureMethod Algorithm="http://www.w3.org/2001/04/xmldsig-more#rsa-sha256"/>', $xmlMetadataSigned);
+        $this->assertStringContainsString('<ds:DigestMethod Algorithm="http://www.w3.org/2001/04/xmlenc#sha512"/>', $xmlMetadataSigned);
         $res5 = new DOMDocument();
         $res5->loadXML($xmlMetadataSigned);
         $dsSignature5 = $res5->firstChild->firstChild;
-        $this->assertContains('ds:Signature', $dsSignature5->tagName);
+        $this->assertStringContainsString('ds:Signature', $dsSignature5->tagName);
     }
 
     /**
@@ -1213,7 +1213,7 @@ class UtilsTest extends \PHPUnit\Framework\TestCase
             $this->assertFalse(Utils::validateSign($dom, $cert));
             $this->fail('Exception was not raised');
         } catch (Exception $e) {
-            $this->assertContains('Reference validation failed', $e->getMessage());
+            $this->assertStringContainsString('Reference validation failed', $e->getMessage());
         }
 
         $dom2 = new DOMDocument();
@@ -1229,7 +1229,7 @@ class UtilsTest extends \PHPUnit\Framework\TestCase
             $this->assertTrue(Utils::validateSign($assertElem2, $cert));
             $this->fail('Exception was not raised');
         } catch (Exception $e) {
-            $this->assertContains('Reference validation failed', $e->getMessage());
+            $this->assertStringContainsString('Reference validation failed', $e->getMessage());
         }
 
         $invalidFingerprint = 'afe71c34ef740bc87434be13a2263d31271da1f9';
@@ -1240,7 +1240,7 @@ class UtilsTest extends \PHPUnit\Framework\TestCase
             $this->assertFalse(Utils::validateSign($noSigned, $cert));
             $this->fail('Exception was not raised');
         } catch (Exception $e) {
-            $this->assertContains('Cannot locate Signature Node', $e->getMessage());
+            $this->assertStringContainsString('Cannot locate Signature Node', $e->getMessage());
         }
 
         $noKey = base64_decode(file_get_contents(TEST_ROOT . '/data/responses/invalids/no_key.xml.base64'));
@@ -1248,7 +1248,7 @@ class UtilsTest extends \PHPUnit\Framework\TestCase
             $this->assertFalse(Utils::validateSign($noKey, $cert));
             $this->fail('Exception was not raised');
         } catch (Exception $e) {
-            $this->assertContains('We have no idea about the key', $e->getMessage());
+            $this->assertStringContainsString('We have no idea about the key', $e->getMessage());
         }
 
         $signatureWrapping = base64_decode(file_get_contents(TEST_ROOT . '/data/responses/invalids/signature_wrapping_attack.xml.base64'));
@@ -1256,7 +1256,7 @@ class UtilsTest extends \PHPUnit\Framework\TestCase
             $this->assertFalse(Utils::validateSign($signatureWrapping, $cert));
             $this->fail('Exception was not raised');
         } catch (Exception $e) {
-            $this->assertContains('Reference validation failed', $e->getMessage());
+            $this->assertStringContainsString('Reference validation failed', $e->getMessage());
         }
     }
 }


### PR DESCRIPTION
This depends on PR https://github.com/onelogin/php-saml/pull/458, which should be pulled in first.

This does a few things:

1. Makes the min PHP version 7.1
2. Updates phpunit for php8 (while allowing a phpunit version for php 7.1+)
3. Cleans up errors related to phpunit depreciations/changes

We still get 2 errors in phpunit to deal with:

1. Errors `Test was run in child process and ended unexpectedly`
2. This last error, which I'm not sure about:

```
22) OneLogin\Saml2\Tests\ResponseTest::testIsInValidCert
Failed asserting that two strings are equal.
--- Expected
+++ Actual
@@ @@
-'openssl_x509_read(): supplied parameter cannot be coerced into an X509 certificate!'
+'openssl_x509_read(): X.509 Certificate cannot be retrieved'
```