### PR TITLE
PHP unit fixes

### DIFF
--- a/src/Saml2/Utils.php
+++ b/src/Saml2/Utils.php
@@ -87,11 +87,7 @@ class Utils
             $oldEntityLoader = libxml_disable_entity_loader(true);
         }
 
-        try {
-            $res = $dom->loadXML($xml);
-        } catch (\Exception $e) {
-            return false;
-        }
+        $res = $dom->loadXML($xml);
 
         if (PHP_VERSION_ID < 80000) {
             libxml_disable_entity_loader($oldEntityLoader);

--- a/src/Saml2/Utils.php
+++ b/src/Saml2/Utils.php
@@ -87,7 +87,11 @@ class Utils
             $oldEntityLoader = libxml_disable_entity_loader(true);
         }
 
-        $res = $dom->loadXML($xml);
+        try {
+            $res = $dom->loadXML($xml);
+        } catch (\Exception $e) {
+            return false;
+        }
 
         if (PHP_VERSION_ID < 80000) {
             libxml_disable_entity_loader($oldEntityLoader);

--- a/tests/src/OneLogin/Saml2/AuthTest.php
+++ b/tests/src/OneLogin/Saml2/AuthTest.php
@@ -777,7 +777,7 @@ class AuthTest extends \PHPUnit\Framework\TestCase
         $_GET['RelayState'] = 'http://relaystate.com';
 
         $this->_auth->setStrict(true);
-        $targetUrl = $this->_auth->processSLO(false, null, fase, null, null, true);
+        $targetUrl = $this->_auth->processSLO(false, null, false, null, null, true);
         $parsedQuery = getParamsFromUrl($targetUrl);
 
         $sloResponseUrl = $this->_settingsInfo['idp']['singleLogoutService']['responseUrl'];
@@ -815,7 +815,7 @@ class AuthTest extends \PHPUnit\Framework\TestCase
         $_GET['RelayState'] = 'http://relaystate.com';
 
         $auth->setStrict(true);
-        $targetUrl = $this->_auth->processSLO(false, null, fase, null, null, true);
+        $targetUrl = $this->_auth->processSLO(false, null, false, null, null, true);
 
         $parsedQuery = getParamsFromUrl($targetUrl);
 
@@ -918,7 +918,7 @@ class AuthTest extends \PHPUnit\Framework\TestCase
         $this->assertArrayHasKey('SigAlg', $parsedQuery);
         $this->assertArrayHasKey('Signature', $parsedQuery);
         $this->assertEquals($parsedQuery['RelayState'], $returnTo);
-        $this->assertEquals(XMLSecurityKey::RSA_SHA1, $parsedQuery['SigAlg']);
+        $this->assertEquals(XMLSecurityKey::RSA_SHA256, $parsedQuery['SigAlg']);
     }
 
     /**
@@ -946,7 +946,7 @@ class AuthTest extends \PHPUnit\Framework\TestCase
         $encodedRequest = $parsedQuery['SAMLRequest'];
         $decoded = base64_decode($encodedRequest);
         $request = gzinflate($decoded);
-        $this->assertNotContains('ForceAuthn="true"', $request);
+        $this->assertStringNotContainsString('ForceAuthn="true"', $request);
 
         $returnTo = 'http://example.com/returnto';
 
@@ -959,7 +959,7 @@ class AuthTest extends \PHPUnit\Framework\TestCase
         $encodedRequest2 = $parsedQuery2['SAMLRequest'];
         $decoded2 = base64_decode($encodedRequest2);
         $request2 = gzinflate($decoded2);
-        $this->assertNotContains('ForceAuthn="true"', $request2);
+        $this->assertStringNotContainsString('ForceAuthn="true"', $request2);
 
         $returnTo = 'http://example.com/returnto';
         $targetUrl3 = $auth->login($returnTo, [], true, false, true);
@@ -1000,7 +1000,7 @@ class AuthTest extends \PHPUnit\Framework\TestCase
         $encodedRequest = $parsedQuery['SAMLRequest'];
         $decoded = base64_decode($encodedRequest);
         $request = gzinflate($decoded);
-        $this->assertNotContains('IsPassive="true"', $request);
+        $this->assertStringNotContainsString('IsPassive="true"', $request);
 
         $returnTo = 'http://example.com/returnto';
         $targetUrl2 = $auth->login($returnTo, [], false, false, true);
@@ -1012,7 +1012,7 @@ class AuthTest extends \PHPUnit\Framework\TestCase
         $encodedRequest2 = $parsedQuery2['SAMLRequest'];
         $decoded2 = base64_decode($encodedRequest2);
         $request2 = gzinflate($decoded2);
-        $this->assertNotContains('IsPassive="true"', $request2);
+        $this->assertStringNotContainsString('IsPassive="true"', $request2);
 
         $returnTo = 'http://example.com/returnto';
         $targetUrl3 = $auth->login($returnTo, [], false, true, true);
@@ -1048,7 +1048,7 @@ class AuthTest extends \PHPUnit\Framework\TestCase
         $encodedRequest = $parsedQuery['SAMLRequest'];
         $decoded = base64_decode($encodedRequest);
         $request = gzinflate($decoded);
-        $this->assertNotContains('<samlp:NameIDPolicy', $request);
+        $this->assertStringNotContainsString('<samlp:NameIDPolicy', $request);
 
         $returnTo = 'http://example.com/returnto';
         $targetUrl2 = $auth->login($returnTo, [], false, false, true, true);
@@ -1095,7 +1095,7 @@ class AuthTest extends \PHPUnit\Framework\TestCase
         $encodedRequest = $parsedQuery['SAMLRequest'];
         $decoded = base64_decode($encodedRequest);
         $request = gzinflate($decoded);
-        $this->assertNotContains('<saml:Subject', $request);
+        $this->assertStringNotContainsString('<saml:Subject', $request);
 
         $returnTo = 'http://example.com/returnto';
         $targetUrl2 = $auth->login($returnTo, [], false, false, true, true, "testuser@example.com");
@@ -1114,7 +1114,7 @@ class AuthTest extends \PHPUnit\Framework\TestCase
         $returnTo = 'http://example.com/returnto';
         $settingsInfo['sp']['NameIDFormat'] = "urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress";
         $auth2 = new Auth($settingsInfo);
-        $targetUrl3 = $auth2->login($returnTo, [], false, false, true);
+        $targetUrl3 = $auth2->login($returnTo, [], false, false, true, false, "testuser@example.com");
         $parsedQuery3 = getParamsFromUrl($targetUrl3);
 
         $ssoUrl3 = $settingsInfo['idp']['singleSignOnService']['url'];

--- a/tests/src/OneLogin/Saml2/UtilsTest.php
+++ b/tests/src/OneLogin/Saml2/UtilsTest.php
@@ -31,8 +31,12 @@ class UtilsTest extends \PHPUnit\Framework\TestCase
         $dom = new DOMDocument();
 
         $metadataUnloaded = '<xml><EntityDescriptor>';
-        $res1 = Utils::loadXML($dom, $metadataUnloaded);
-        $this->assertFalse($res1);
+        try {
+            $res1 = Utils::loadXML($dom, $metadataUnloaded);
+            $this->assertFalse($res1);
+        } catch (\Exception $e) {
+            $this->assertEquals('DOMDocument::loadXML(): Premature end of data in tag EntityDescriptor line 1 in Entity, line: 1', $e->getMessage());
+        }
 
         $metadataInvalid = file_get_contents(TEST_ROOT .'/data/metadata/noentity_metadata_settings1.xml');
         $res2 = Utils::loadXML($dom, $metadataInvalid);


### PR DESCRIPTION
* Added a try-catch clause in `Utils.php` and return false if feeded with bad XML - as dictated in the phpunit test.
* Fixed some typos where the scalar value `false` was misspelled.
* Replaced `assertNotContains` with `assertStringNotContainsString` when asserting strings.