### PR TITLE
Encode sso and slo url in request xml

### DIFF
--- a/lib/Saml2/AuthnRequest.php
+++ b/lib/Saml2/AuthnRequest.php
@@ -133,7 +133,7 @@ REQUESTEDAUTHN;
 
         $spEntityId = htmlspecialchars($spData['entityId'], ENT_QUOTES);
         $acsUrl = htmlspecialchars($spData['assertionConsumerService']['url'], ENT_QUOTES);
-        $destination = $this->_settings->getIdPSSOUrl();
+        $destination = htmlspecialchars($this->_settings->getIdPSSOUrl(), ENT_QUOTES);
         $request = <<<AUTHNREQUEST
 <samlp:AuthnRequest
     xmlns:samlp="urn:oasis:names:tc:SAML:2.0:protocol"

--- a/lib/Saml2/LogoutRequest.php
+++ b/lib/Saml2/LogoutRequest.php
@@ -106,7 +106,7 @@ class OneLogin_Saml2_LogoutRequest
             $sessionIndexStr = isset($sessionIndex) ? "<samlp:SessionIndex>{$sessionIndex}</samlp:SessionIndex>" : "";
 
             $spEntityId = htmlspecialchars($spData['entityId'], ENT_QUOTES);
-            $destination = $this->_settings->getIdPSLOUrl();
+            $destination = htmlspecialchars($this->_settings->getIdPSLOUrl(), ENT_QUOTES);
             $logoutRequest = <<<LOGOUTREQUEST
 <samlp:LogoutRequest
     xmlns:samlp="urn:oasis:names:tc:SAML:2.0:protocol"


### PR DESCRIPTION
The Auth and logout requests are invalid when the SSO and/or the SLO url contain invalid characters (for example an: &)