### PR TITLE
Utils redirect returns a psr7 ResponseInterface

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,6 +16,7 @@
     },
     "require": {
         "php": ">=7.3",
+        "guzzlehttp/guzzle": "^7.3",
         "robrichards/xmlseclibs": ">=3.1.1"
     },
     "require-dev": {

--- a/demo1/attrs.php
+++ b/demo1/attrs.php
@@ -1,25 +1,27 @@
 <?php
 
 session_start();
-
+$html = '';
 if (isset($_SESSION['samlUserdata'])) {
     if (!empty($_SESSION['samlUserdata'])) {
         $attributes = $_SESSION['samlUserdata'];
-        echo 'You have the following attributes:<br>';
-        echo '<table><thead><th>Name</th><th>Values</th></thead><tbody>';
+        $html .= 'You have the following attributes:<br>';
+        $html .= '<table><thead><th>Name</th><th>Values</th></thead><tbody>';
         foreach ($attributes as $attributeName => $attributeValues) {
-            echo '<tr><td>' . htmlentities($attributeName) . '</td><td><ul>';
+            $html .= '<tr><td>' . htmlentities($attributeName) . '</td><td><ul>';
             foreach ($attributeValues as $attributeValue) {
-                echo '<li>' . htmlentities($attributeValue) . '</li>';
+                $html .= '<li>' . htmlentities($attributeValue) . '</li>';
             }
-            echo '</ul></td></tr>';
+            $html .= '</ul></td></tr>';
         }
-        echo '</tbody></table>';
+        $html .= '</tbody></table>';
     } else {
-        echo "<p>You don't have any attribute</p>";
+        $html .= "<p>You don't have any attribute</p>";
     }
 
-    echo '<p><a href="index.php?slo" >Logout</a></p>';
+    $html .= '<p><a href="index.php?slo" >Logout</a></p>';
 } else {
-    echo '<p><a href="index.php?sso2" >Login and access later to this page</a></p>';
+    $html .= '<p><a href="index.php?sso2" >Login and access later to this page</a></p>';
 }
+
+return new \GuzzleHttp\Psr7\Response(200, [], $html);

--- a/demo1/metadata.php
+++ b/demo1/metadata.php
@@ -19,8 +19,7 @@ try {
     $metadata = $settings->getSPMetadata();
     $errors = $settings->validateMetadata($metadata);
     if (empty($errors)) {
-        header('Content-Type: text/xml');
-        echo $metadata;
+	    return new \GuzzleHttp\Psr7\Response(500, ['Content-Type', 'text/xml'], $metadata);
     } else {
         throw new Error(
             'Invalid SP metadata: '.implode(', ', $errors),
@@ -28,5 +27,5 @@ try {
         );
     }
 } catch (Exception $e) {
-    echo $e->getMessage();
+	return new \GuzzleHttp\Psr7\Response(500, [], $e->getMessage());
 }

--- a/demo2/metadata.php
+++ b/demo2/metadata.php
@@ -11,10 +11,9 @@ require_once dirname(__DIR__).'/_toolkit_loader.php';
 use OneLogin\Saml2\Metadata;
 use OneLogin\Saml2\Settings;
 
-header('Content-Type: text/xml');
-
 $samlSettings = new Settings();
 $sp = $samlSettings->getSPData();
 
 $samlMetadata = Metadata::builder($sp);
-echo $samlMetadata;
+
+return new \GuzzleHttp\Psr7\Response(200, ['Content-Type' => 'text/xml'], $samlMetadata);

--- a/demo2/slo.php
+++ b/demo2/slo.php
@@ -14,6 +14,9 @@ use OneLogin\Saml2\LogoutRequest;
 use OneLogin\Saml2\Settings;
 use OneLogin\Saml2\Utils;
 
+/** @var \GuzzleHttp\Psr7\ServerRequest $request */
+$request = \GuzzleHttp\Psr7\ServerRequest::fromGlobals();
+
 $samlSettings = new Settings();
 
 $idpData = $samlSettings->getIdPData();
@@ -33,6 +36,4 @@ $samlRequest = $logoutRequest->getRequest();
 
 $parameters = array('SAMLRequest' => $samlRequest);
 
-$url = Utils::redirect($sloUrl, $parameters, true);
-
-header("Location: $url");
+return Utils::redirect($sloUrl, $parameters);

--- a/demo2/sso.php
+++ b/demo2/sso.php
@@ -18,8 +18,8 @@ use OneLogin\Saml2\Utils;
 $auth = new OneLogin\Saml2\Auth();
 
 if (!isset($_SESSION['samlUserdata'])) {
-    $auth->login();
+    return $auth->login();
 } else {
     $indexUrl = str_replace('/sso.php', '/index.php', Utils::getSelfURLNoQuery());
-    Utils::redirect($indexUrl);
+    return Utils::redirect($indexUrl);
 }

--- a/src/Saml2/Auth.php
+++ b/src/Saml2/Auth.php
@@ -15,6 +15,7 @@
 
 namespace OneLogin\Saml2;
 
+use Psr\Http\Message\ResponseInterface;
 use RobRichards\XMLSecLibs\XMLSecurityKey;
 
 use Exception;
@@ -270,12 +271,16 @@ class Auth
      * @param callable    $cbDeleteSession              Callback to be executed to delete session
      * @param bool        $stay                         True if we want to stay (returns the url string) False to redirect
      *
-     * @return string|null
+     * @return string|ResponseInterface
      *
      * @throws Error
      */
-    public function processSLO($keepLocalSession = false, $requestId = null, $retrieveParametersFromServer = false, $cbDeleteSession = null, $stay = false)
+    public function processSLO($keepLocalSession = false, $requestId = null, $retrieveParametersFromServer = false, $cbDeleteSession = null, $stay = false): ResponseInterface
     {
+        if ($stay !== false) {
+            trigger_error('stay is deprecated and will be removed in a future release', E_USER_NOTICE);
+        }
+
         $this->_errors = array();
         $this->_lastError = $this->_lastErrorException = null;
         if (isset($_GET['SAMLResponse'])) {
@@ -352,10 +357,13 @@ class Auth
      * @param array  $parameters Extra parameters to be passed as part of the url
      * @param bool   $stay       True if we want to stay (returns the url string) False to redirect
      *
-     * @return string|null
+     * @return string|ResponseInterface
      */
-    public function redirectTo($url = '', array $parameters = array(), $stay = false)
+    public function redirectTo($url = '', array $parameters = array(), $stay = false): ResponseInterface
     {
+        if ($stay !== false) {
+            trigger_error('stay is deprecated and will be removed in a future release', E_USER_NOTICE);
+        }
         assert(is_string($url));
 
         if (empty($url) && isset($_REQUEST['RelayState'])) {
@@ -533,12 +541,16 @@ class Auth
      * @param bool        $setNameIdPolicy When true the AuthNRequest will set a nameIdPolicy element
      * @param string      $nameIdValueReq  Indicates to the IdP the subject that should be authenticated
      *
-     * @return string|null If $stay is True, it return a string with the SLO URL + LogoutRequest + parameters
+     * @return string|ResponseInterface
      *
      * @throws Error
      */
-    public function login($returnTo = null, array $parameters = array(), $forceAuthn = false, $isPassive = false, $stay = false, $setNameIdPolicy = true, $nameIdValueReq = null)
+    public function login($returnTo = null, array $parameters = array(), $forceAuthn = false, $isPassive = false, $stay = false, $setNameIdPolicy = true, $nameIdValueReq = null): ResponseInterface
     {
+        if ($stay !== false) {
+            trigger_error('stay is deprecated and will be removed in a future release', E_USER_NOTICE);
+        }
+
         $authnRequest = $this->buildAuthnRequest($this->_settings, $forceAuthn, $isPassive, $setNameIdPolicy, $nameIdValueReq);
 
         $this->_lastRequest = $authnRequest->getXML();
@@ -573,12 +585,16 @@ class Auth
      * @param string|null $nameIdFormat        The NameID Format will be set in the LogoutRequest.
      * @param string|null $nameIdNameQualifier The NameID NameQualifier will be set in the LogoutRequest.
      *
-     * @return string|null If $stay is True, it return a string with the SLO URL + LogoutRequest + parameters
+     * @return string|ResponseInterface If $stay is True, it return a string with the SLO URL + LogoutRequest + parameters
      *
      * @throws Error
      */
-    public function logout($returnTo = null, array $parameters = array(), $nameId = null, $sessionIndex = null, $stay = false, $nameIdFormat = null, $nameIdNameQualifier = null, $nameIdSPNameQualifier = null)
+    public function logout($returnTo = null, array $parameters = array(), $nameId = null, $sessionIndex = null, $stay = false, $nameIdFormat = null, $nameIdNameQualifier = null, $nameIdSPNameQualifier = null): ResponseInterface
     {
+        if ($stay !== false) {
+            trigger_error('stay is deprecated and will be removed in a future release', E_USER_NOTICE);
+        }
+
         $sloUrl = $this->getSLOurl();
         if (empty($sloUrl)) {
             throw new Error(
@@ -670,7 +686,7 @@ class Auth
      *
      * @return AuthnRequest The AuthnRequest object
      */
-    public function buildAuthnRequest($settings, $forceAuthn, $isPassive, $setNameIdPolicy, $nameIdValueReq = null)
+    public function buildAuthnRequest($settings, $forceAuthn, $isPassive, $setNameIdPolicy, $nameIdValueReq = null): ResponseInterface
     {
         return new AuthnRequest($settings, $forceAuthn, $isPassive, $setNameIdPolicy, $nameIdValueReq);
     }

--- a/src/Saml2/Auth.php
+++ b/src/Saml2/Auth.php
@@ -275,7 +275,7 @@ class Auth
      *
      * @throws Error
      */
-    public function processSLO($keepLocalSession = false, $requestId = null, $retrieveParametersFromServer = false, $cbDeleteSession = null, $stay = false): ResponseInterface
+    public function processSLO($keepLocalSession = false, $requestId = null, $retrieveParametersFromServer = false, $cbDeleteSession = null, $stay = false)
     {
         if ($stay !== false) {
             trigger_error('stay is deprecated and will be removed in a future release', E_USER_NOTICE);
@@ -359,7 +359,7 @@ class Auth
      *
      * @return string|ResponseInterface
      */
-    public function redirectTo($url = '', array $parameters = array(), $stay = false): ResponseInterface
+    public function redirectTo($url = '', array $parameters = array(), $stay = false)
     {
         if ($stay !== false) {
             trigger_error('stay is deprecated and will be removed in a future release', E_USER_NOTICE);
@@ -545,7 +545,7 @@ class Auth
      *
      * @throws Error
      */
-    public function login($returnTo = null, array $parameters = array(), $forceAuthn = false, $isPassive = false, $stay = false, $setNameIdPolicy = true, $nameIdValueReq = null): ResponseInterface
+    public function login($returnTo = null, array $parameters = array(), $forceAuthn = false, $isPassive = false, $stay = false, $setNameIdPolicy = true, $nameIdValueReq = null)
     {
         if ($stay !== false) {
             trigger_error('stay is deprecated and will be removed in a future release', E_USER_NOTICE);
@@ -589,7 +589,7 @@ class Auth
      *
      * @throws Error
      */
-    public function logout($returnTo = null, array $parameters = array(), $nameId = null, $sessionIndex = null, $stay = false, $nameIdFormat = null, $nameIdNameQualifier = null, $nameIdSPNameQualifier = null): ResponseInterface
+    public function logout($returnTo = null, array $parameters = array(), $nameId = null, $sessionIndex = null, $stay = false, $nameIdFormat = null, $nameIdNameQualifier = null, $nameIdSPNameQualifier = null)
     {
         if ($stay !== false) {
             trigger_error('stay is deprecated and will be removed in a future release', E_USER_NOTICE);
@@ -686,7 +686,7 @@ class Auth
      *
      * @return AuthnRequest The AuthnRequest object
      */
-    public function buildAuthnRequest($settings, $forceAuthn, $isPassive, $setNameIdPolicy, $nameIdValueReq = null): ResponseInterface
+    public function buildAuthnRequest($settings, $forceAuthn, $isPassive, $setNameIdPolicy, $nameIdValueReq = null)
     {
         return new AuthnRequest($settings, $forceAuthn, $isPassive, $setNameIdPolicy, $nameIdValueReq);
     }

--- a/src/Saml2/Utils.php
+++ b/src/Saml2/Utils.php
@@ -15,6 +15,7 @@
 
 namespace OneLogin\Saml2;
 
+use Psr\Http\Message\ResponseInterface;
 use RobRichards\XMLSecLibs\XMLSecurityKey;
 use RobRichards\XMLSecLibs\XMLSecurityDSig;
 use RobRichards\XMLSecLibs\XMLSecEnc;
@@ -303,12 +304,15 @@ class Utils
      * @param array  $parameters Extra parameters to be passed as part of the url
      * @param bool   $stay       True if we want to stay (returns the url string) False to redirect
      *
-     * @return string|null $url
+     * @return string|ResponseInterface $url
      *
      * @throws Error
      */
-    public static function redirect($url, array $parameters = array(), $stay = false)
+    public static function redirect($url, array $parameters = array(), $stay = false): ResponseInterface
     {
+        if ($stay !== false) {
+            trigger_error('stay is deprecated and will be removed in a future release', E_USER_NOTICE);
+        }
         assert(is_string($url));
 
         if (substr($url, 0, 1) === '/') {
@@ -360,10 +364,7 @@ class Utils
             return $url;
         }
 
-        header('Pragma: no-cache');
-        header('Cache-Control: no-cache, must-revalidate');
-        header('Location: ' . $url);
-        exit();
+        return new \GuzzleHttp\Psr7\Response(302, ['location' => [(string) $url]]);
     }
 
      /**

--- a/src/Saml2/Utils.php
+++ b/src/Saml2/Utils.php
@@ -308,7 +308,7 @@ class Utils
      *
      * @throws Error
      */
-    public static function redirect($url, array $parameters = array(), $stay = false): ResponseInterface
+    public static function redirect($url, array $parameters = array(), $stay = false)
     {
         if ($stay !== false) {
             trigger_error('stay is deprecated and will be removed in a future release', E_USER_NOTICE);


### PR DESCRIPTION
Hi,

I'm using this library within a project that has psr7 request/response handling. The only problem is that this library redirects within the `OneLogin\Saml2\Utils::redirect()` method, which breaks the routing flow and bypasses my middlewares. If we simply make this method return a ResponseInterface instead of redirecting, this library becomes really simple to integrate with any project that uses psr7 request/response handling.

* Replaced the redirect logic within this library
* Updated demo1 and demo2 examples

Ref #162 