### PR TITLE
Make `Saml2\Auth` can accept a param `$spValidationOnly`

### DIFF
--- a/lib/Saml2/Auth.php
+++ b/lib/Saml2/Auth.php
@@ -144,12 +144,13 @@ class OneLogin_Saml2_Auth
      * Initializes the SP SAML instance.
      *
      * @param array|object|null $oldSettings Setting data (You can provide a OneLogin_Saml_Settings, the settings object of the Saml folder implementation)
+     * @param bool $spValidationOnly if you only as an SP , you should set it to false if not you should set it to true
      *
      * @throws OneLogin_Saml2_Error
      */
-    public function __construct($oldSettings = null)
+    public function __construct($oldSettings = null , $spValidationOnly = true)
     {
-        $this->_settings = new OneLogin_Saml2_Settings($oldSettings);
+        $this->_settings = new OneLogin_Saml2_Settings($oldSettings, $spValidationOnly);
     }
 
     /**

--- a/tests/src/OneLogin/Saml2/SettingsTest.php
+++ b/tests/src/OneLogin/Saml2/SettingsTest.php
@@ -1164,4 +1164,17 @@ class OneLogin_Saml2_SettingsTest extends PHPUnit_Framework_TestCase
         $settings3 = new OneLogin_Saml2_Settings($settingsInfo);
         $this->assertTrue($settings3->isDebugActive());
     }
+    /**
+     * Tests the checkSettings method of the OneLogin_Saml2_Settings
+     *
+     * @covers OneLogin_Saml2_Settings::checkSettings
+     */
+    public function testSpValidateOnlyIsTrue()
+    {
+        $settingsDir = TEST_ROOT .'/settings/';
+        include $settingsDir.'settings2.php';
+        unset($settingsInfo['idp']);
+        $settings = new OneLogin_Saml2_Settings($settingsInfo,true);
+        $this->assertEmpty($settings->getErrors());
+    }
 }


### PR DESCRIPTION
The user who uses this package can decide if they want to make `$spValidationOnly` to be true