### PR TITLE
Compatibility with PHP 8.1

### DIFF
--- a/src/Saml2/Response.php
+++ b/src/Saml2/Response.php
@@ -269,7 +269,10 @@ class Response
 
                 // Check destination
                 if ($this->document->documentElement->hasAttribute('Destination')) {
-                    $destination = trim($this->document->documentElement->getAttribute('Destination'));
+                    $destination = $this->document->documentElement->getAttribute('Destination');
+                    if (isset($destination)) {
+                        $destination = trim($destination);
+                    }
                     if (empty($destination)) {
                         if (!$security['relaxDestinationValidation']) {
                             throw new ValidationError(
@@ -308,12 +311,14 @@ class Response
                 // Check the issuers
                 $issuers = $this->getIssuers();
                 foreach ($issuers as $issuer) {
-                    $trimmedIssuer = trim($issuer);
-                    if (empty($trimmedIssuer) || $trimmedIssuer !== $idPEntityId) {
-                        throw new ValidationError(
-                            "Invalid issuer in the Assertion/Response (expected '$idPEntityId', got '$trimmedIssuer')",
-                            ValidationError::WRONG_ISSUER
-                        );
+                    if (isset($issuer)) {
+                        $trimmedIssuer = trim($issuer);
+                        if (empty($trimmedIssuer) || $trimmedIssuer !== $idPEntityId) {
+                            throw new ValidationError(
+                                "Invalid issuer in the Assertion/Response (expected '$idPEntityId', got '$trimmedIssuer')",
+                                ValidationError::WRONG_ISSUER
+                            );
+                        }
                     }
                 }
 
@@ -554,7 +559,10 @@ class Response
 
         $entries = $this->_queryAssertion('/saml:Conditions/saml:AudienceRestriction/saml:Audience');
         foreach ($entries as $entry) {
-            $value = trim($entry->textContent);
+            $value = $entry->textContent;
+            if (isset($value)) {
+                $value = trim($value);
+            }
             if (!empty($value)) {
                 $audiences[] = $value;
             }

--- a/src/Saml2/Utils.php
+++ b/src/Saml2/Utils.php
@@ -221,6 +221,10 @@ class Utils
      */
     public static function formatCert($cert, $heads = true)
     {
+        if (is_null($cert)) {
+          return;
+        }
+
         $x509cert = str_replace(array("\x0D", "\r", "\n"), "", $cert);
         if (!empty($x509cert)) {
             $x509cert = str_replace('-----BEGIN CERTIFICATE-----', "", $x509cert);
@@ -245,6 +249,10 @@ class Utils
      */
     public static function formatPrivateKey($key, $heads = true)
     {
+        if (is_null($key)) {
+          return;
+        }
+
         $key = str_replace(array("\x0D", "\r", "\n"), "", $key);
         if (!empty($key)) {
             if (strpos($key, '-----BEGIN PRIVATE KEY-----') !== false) {
@@ -319,7 +327,12 @@ class Utils
          * Verify that the URL matches the regex for the protocol.
          * By default this will check for http and https
          */
-        $wrongProtocol = !preg_match(self::$_protocolRegex, $url);
+        if (isset(self::$_protocolRegex)) {
+            $protocol = $_protocolRegex;
+        } else {
+            $protocol = "";
+        }
+        $wrongProtocol = !preg_match($protocol, $url);
         $url = filter_var($url, FILTER_VALIDATE_URL);
         if ($wrongProtocol || empty($url)) {
             throw new Error(
@@ -773,6 +786,10 @@ class Utils
      */
     public static function parseSAML2Time($time)
     {
+        if (empty($time)) {
+          return null;
+        }
+
         $matches = array();
 
         /* We use a very strict regex to parse the timestamp. */
@@ -1010,7 +1027,10 @@ class Utils
                 if (strncmp($curData, '-----END CERTIFICATE', 20) == 0) {
                     break;
                 }
-                $data .= trim($curData);
+                if (isset($curData)) {
+                    $curData = trim($curData);
+                }
+                $data .= $curData;
             }
         }
 
@@ -1043,6 +1063,9 @@ class Utils
      */
     public static function formatFingerPrint($fingerprint)
     {
+        if (is_null($fingerprint)) {
+            return;
+        }
         $formatedFingerprint = str_replace(':', '', $fingerprint);
         $formatedFingerprint = strtolower($formatedFingerprint);
         return $formatedFingerprint;


### PR DESCRIPTION
This changes add compatibility with PHP 8.1

If null param are provided to trim or preg_match, when PHP 8.1 has deprecation errors enabled, php-saml will raise errors.