### PR TITLE
Use X-Forwarded-Proto to determine port

### DIFF
--- a/lib/Saml2/Utils.php
+++ b/lib/Saml2/Utils.php
@@ -573,8 +573,8 @@ class OneLogin_Saml2_Utils
         $portnumber = null;
         if (self::$_port) {
             $portnumber = self::$_port;
-        } else if (self::getProxyVars() && isset($_SERVER["HTTP_X_FORWARDED_PORT"])) {
-            $portnumber = $_SERVER["HTTP_X_FORWARDED_PORT"];
+        } else if (self::getProxyVars() && self::determinePortFromProxyVars() !== null) {
+            $portnumber = self::determinePortFromProxyVars();
         } else if (isset($_SERVER["SERVER_PORT"])) {
             $portnumber = $_SERVER["SERVER_PORT"];
         } else {
@@ -589,6 +589,23 @@ class OneLogin_Saml2_Utils
             }
         }
         return $portnumber;
+    }
+
+    /**
+     * @return null|string The port number inferred from the proxy variables (HTTP_X_FORWARDED_...)
+     */
+    private static function determinePortFromProxyVars()
+    {
+        if (isset($_SERVER["HTTP_X_FORWARDED_PORT"])) {
+            return $_SERVER["HTTP_X_FORWARDED_PORT"];
+        } else if (isset($_SERVER["HTTP_X_FORWARDED_PROTO"])) {
+            if ($_SERVER["HTTP_X_FORWARDED_PROTO"] == 'https') {
+                return '443';
+            } elseif ($_SERVER["HTTP_X_FORWARDED_PROTO"] == 'http') {
+                return '80';
+            }
+        }
+        return null;
     }
 
     /**


### PR DESCRIPTION
Using `X-Forwarded-Port` seems to be discouraged as it allows spoofing according to the Caddy proxy devs [0]:

"For these X-Forwarded-* headers, by default, the proxy will ignore their values from incoming requests, to prevent spoofing."

Instead we should use the X-Forwarded-Proto header to infer the port that the proxy was called at. So https indicates port 443, while http indicates port 80.

Fixes #633

[0]: https://caddyserver.com/docs/caddyfile/directives/reverse_proxy?utm_source=chatgpt.com#defaults