### PR TITLE
Fix CVE-2026-32313: Require robrichards/xmlseclibs ^3.1.5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     },
     "require": {
         "php": ">=7.3",
-        "robrichards/xmlseclibs": ">=3.1.4"
+        "robrichards/xmlseclibs": "^3.1.5"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.5",


### PR DESCRIPTION
Fixes #643

Update the  dependency constraint from  to  to address CVE-2026-32313.


## Security Issue
CVE-2026-32313 affects  versions < 3.1.5. The vulnerability involves missing AES-GCM Authentication Tag Validation on Encrypted Nodes which allows for unauthorized decryption.

## References
- https://github.com/advisories/GHSA-4v26-v6cg-g6f9
- https://github.com/SAML-Toolkits/php-saml/issues/643