### PR TITLE
Fix empty responseUrl bypassing SLO URL fallback

### DIFF
--- a/src/Saml2/Settings.php
+++ b/src/Saml2/Settings.php
@@ -863,7 +863,7 @@ class Settings
      */
     public function getIdPSLOResponseUrl()
     {
-        if (isset($this->_idp['singleLogoutService']) && isset($this->_idp['singleLogoutService']['responseUrl'])) {
+        if (isset($this->_idp['singleLogoutService']) && !empty($this->_idp['singleLogoutService']['responseUrl'])) {
             return $this->_idp['singleLogoutService']['responseUrl'];
         }
         return $this->getIdPSLOUrl();


### PR DESCRIPTION
`isset('')` returns `true` in PHP, so an empty `responseUrl` passes the fallbackcheck and `getIdPSLOResponseUrl()` returns `''`. 
This causes `Utils::redirect('')` to throw `REDIRECT_INVALID_URL` during broadcast SLO.
Replace `isset()` with `!empty()` so empty strings correctly fall through to `getIdPSLOUrl()`.